### PR TITLE
Change Android minSdk to 21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.5.2"
 android-compileSdk = "34"
-android-minSdk = "24"
+android-minSdk = "21"
 android-targetSdk = "34"
 compose = "1.7.1"
 compose-androidx = "1.7.5"


### PR DESCRIPTION
It would be nice to support a wider range of Android devices by setting minSdk to 21. Treat it as a suggestion, for now, it compiles successfully with minSdk 21, but I don't know if there are plans to use any functionality available only on SDK 24 and above, so feel free to reject the PR.