### PR TITLE
document Anchors

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
-import dev.sargunv.maplibrecompose.compose.layer.Anchor
+import dev.sargunv.maplibrecompose.compose.layer.AnchorBelow
 import dev.sargunv.maplibrecompose.compose.layer.LineLayer
 import dev.sargunv.maplibrecompose.compose.rememberCameraState
 import dev.sargunv.maplibrecompose.compose.source.rememberGeoJsonSource
@@ -48,7 +48,7 @@ fun AnimatedLayerDemo() = Column {
           ),
       )
 
-    Anchor.Below("waterway_line_label") {
+    AnchorBelow("waterway_line_label") {
       LineLayer(
         id = "amtrak-routes",
         source = routeSource,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/StyleManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/StyleManager.kt
@@ -151,11 +151,15 @@ internal class StyleManager(var style: Style, private var logger: Logger?) {
   }
 
   private fun Anchor.validate() {
-    when (this) {
-      is Anchor.WithLayerId ->
-        require(baseLayers.containsKey(layerId)) { "Layer ID '$layerId' not found in base style" }
-
-      else -> Unit
+    layerIdOrNull?.let { layerId ->
+      require(baseLayers.containsKey(layerId)) { "Layer ID '$layerId' not found in base style" }
     }
+  }
+
+  private val Anchor.layerIdOrNull: String? get() = when (this) {
+    is Anchor.Above -> layerId
+    is Anchor.Below -> layerId
+    is Anchor.Replace -> layerId
+    else -> null
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/StyleManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/StyleManager.kt
@@ -156,10 +156,12 @@ internal class StyleManager(var style: Style, private var logger: Logger?) {
     }
   }
 
-  private val Anchor.layerIdOrNull: String? get() = when (this) {
-    is Anchor.Above -> layerId
-    is Anchor.Below -> layerId
-    is Anchor.Replace -> layerId
-    else -> null
-  }
+  private val Anchor.layerIdOrNull: String?
+    get() =
+      when (this) {
+        is Anchor.Above -> layerId
+        is Anchor.Below -> layerId
+        is Anchor.Replace -> layerId
+        else -> null
+      }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/Anchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/Anchor.kt
@@ -15,8 +15,8 @@ internal val LocalAnchor: ProvidableCompositionLocal<Anchor> = compositionLocalO
  * This allows for layers declared in Compose to be inserted at any location of the layers defined
  * in the base style JSON rather than exclusively on top of these.
  *
- * See [AnchorTop], [AnchorBottom], [AnchorAbove], [AnchorBelow], [AnchorReplace] to use in the
- * layers composition.
+ * See [AnchorTop], [AnchorBottom], [AnchorAbove], [AnchorBelow], [AnchorReplace] and [AnchorAt] to
+ * use in the layers composition.
  * */
 @Immutable
 public sealed interface Anchor {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/Anchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/Anchor.kt
@@ -8,51 +8,69 @@ import androidx.compose.runtime.compositionLocalOf
 
 internal val LocalAnchor: ProvidableCompositionLocal<Anchor> = compositionLocalOf { Anchor.Top }
 
+/**
+ * Declares where the layers should be anchored, i.e. positioned in the list of layers in the
+ * map style.
+ *
+ * This allows for layers declared in Compose to be inserted at any location of the layers defined
+ * in the base style JSON rather than exclusively on top of these.
+ *
+ * See [AnchorTop], [AnchorBottom], [AnchorAbove], [AnchorBelow], [AnchorReplace] to use in the
+ * layers composition.
+ * */
 @Immutable
 public sealed interface Anchor {
+  /** Layer(s) are anchored at the top, i.e. in front of all other layers */
   public data object Top : Anchor
 
+  /** Layer(s) are anchored at the bottom, i.e. in behind of all other layers */
   public data object Bottom : Anchor
 
-  public data class Above(override val layerId: String) : WithLayerId
+  /** Layer(s) are anchored above the layer with the given [layerId], i.e. in front of it. */
+  public data class Above(val layerId: String) : Anchor
 
-  public data class Below(override val layerId: String) : WithLayerId
+  /** Layer(s) are anchored below the layer with the given [layerId], i.e. behind it. */
+  public data class Below(val layerId: String) : Anchor
 
-  public data class Replace(override val layerId: String) : WithLayerId
+  /** Layer(s) replace the layer with the given [layerId], i.e. are shown instead of it. */
+  public data class Replace(val layerId: String) : Anchor
+}
 
-  public sealed interface WithLayerId : Anchor {
-    public val layerId: String
-  }
+/** The layers specified in [block] are put at the top, i.e. in front of all other layers. */
+@Composable
+public fun AnchorTop(block: @Composable () -> Unit) {
+  CompositionLocalProvider(LocalAnchor provides Anchor.Top) { block() }
+}
 
-  public companion object {
-    @Composable
-    public fun Top(block: @Composable () -> Unit) {
-      CompositionLocalProvider(LocalAnchor provides Top) { block() }
-    }
+/** The layers specified in [block] are put at the bottom, i.e. behind of all other layers. */
+@Composable
+public fun AnchorBottom(block: @Composable () -> Unit) {
+  CompositionLocalProvider(LocalAnchor provides Anchor.Bottom) { block() }
+}
 
-    @Composable
-    public fun Bottom(block: @Composable () -> Unit) {
-      CompositionLocalProvider(LocalAnchor provides Bottom) { block() }
-    }
+/** The layers specified in [block] are put above the layer with the given [layerId],
+ *  i.e. in front of it. */
+@Composable
+public fun AnchorAbove(layerId: String, block: @Composable () -> Unit) {
+  CompositionLocalProvider(LocalAnchor provides Anchor.Above(layerId)) { block() }
+}
 
-    @Composable
-    public fun Above(layerId: String, block: @Composable () -> Unit) {
-      CompositionLocalProvider(LocalAnchor provides Above(layerId)) { block() }
-    }
+/** The layers specified in [block] are put below the layer with the given [layerId],
+ *  i.e. behind it. */
+@Composable
+public fun AnchorBelow(layerId: String, block: @Composable () -> Unit) {
+  CompositionLocalProvider(LocalAnchor provides Anchor.Below(layerId)) { block() }
+}
 
-    @Composable
-    public fun Below(layerId: String, block: @Composable () -> Unit) {
-      CompositionLocalProvider(LocalAnchor provides Below(layerId)) { block() }
-    }
+/** The layers specified in [block] replace the layer with the given [layerId],
+ *  i.e. are shown instead of it. */
+@Composable
+public fun AnchorReplace(layerId: String, block: @Composable () -> Unit) {
+  CompositionLocalProvider(LocalAnchor provides Anchor.Replace(layerId)) { block() }
+}
 
-    @Composable
-    public fun Replace(layerId: String, block: @Composable () -> Unit) {
-      CompositionLocalProvider(LocalAnchor provides Replace(layerId)) { block() }
-    }
-
-    @Composable
-    public fun Of(anchor: Anchor, block: @Composable () -> Unit) {
-      CompositionLocalProvider(LocalAnchor provides anchor) { block() }
-    }
-  }
+/** The layers specified in [block] are put at the given [Anchor]. */
+@Composable
+public fun AnchorAt(anchor: Anchor, block: @Composable () -> Unit) {
+  CompositionLocalProvider(LocalAnchor provides anchor) { block() }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/Anchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/Anchor.kt
@@ -9,15 +9,15 @@ import androidx.compose.runtime.compositionLocalOf
 internal val LocalAnchor: ProvidableCompositionLocal<Anchor> = compositionLocalOf { Anchor.Top }
 
 /**
- * Declares where the layers should be anchored, i.e. positioned in the list of layers in the
- * map style.
+ * Declares where the layers should be anchored, i.e. positioned in the list of layers in the map
+ * style.
  *
  * This allows for layers declared in Compose to be inserted at any location of the layers defined
  * in the base style JSON rather than exclusively on top of these.
  *
  * See [AnchorTop], [AnchorBottom], [AnchorAbove], [AnchorBelow], [AnchorReplace] and [AnchorAt] to
  * use in the layers composition.
- * */
+ */
 @Immutable
 public sealed interface Anchor {
   /** Layer(s) are anchored at the top, i.e. in front of all other layers */
@@ -48,22 +48,27 @@ public fun AnchorBottom(block: @Composable () -> Unit) {
   CompositionLocalProvider(LocalAnchor provides Anchor.Bottom) { block() }
 }
 
-/** The layers specified in [block] are put above the layer with the given [layerId],
- *  i.e. in front of it. */
+/**
+ * The layers specified in [block] are put above the layer with the given [layerId], i.e. in front
+ * of it.
+ */
 @Composable
 public fun AnchorAbove(layerId: String, block: @Composable () -> Unit) {
   CompositionLocalProvider(LocalAnchor provides Anchor.Above(layerId)) { block() }
 }
 
-/** The layers specified in [block] are put below the layer with the given [layerId],
- *  i.e. behind it. */
+/**
+ * The layers specified in [block] are put below the layer with the given [layerId], i.e. behind it.
+ */
 @Composable
 public fun AnchorBelow(layerId: String, block: @Composable () -> Unit) {
   CompositionLocalProvider(LocalAnchor provides Anchor.Below(layerId)) { block() }
 }
 
-/** The layers specified in [block] replace the layer with the given [layerId],
- *  i.e. are shown instead of it. */
+/**
+ * The layers specified in [block] replace the layer with the given [layerId], i.e. are shown
+ * instead of it.
+ */
 @Composable
 public fun AnchorReplace(layerId: String, block: @Composable () -> Unit) {
   CompositionLocalProvider(LocalAnchor provides Anchor.Replace(layerId)) { block() }


### PR DESCRIPTION
I documented the anchors.

But I also:

- replaced `WithLayerId` sealed interface with something internal because actually it is internal. When it is internal, no need to have it on the interface (and document it)

- renamed composable anchor functions so that they don't conflict or can be mistaken with the data classes of the same name

What do you think?