### PR TITLE
Expose screenLocationFromPosition to CameraState

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -51,8 +51,8 @@ public class CameraState internal constructor(firstPosition: CameraPosition) {
     map.animateCameraPosition(finalPosition, duration)
   }
 
-  public fun screenLocationFromPosition(position: Position): Offset? {
-    return map?.screenLocationFromPosition(position)
+  public fun screenLocationFromPosition(position: Position): Offset {
+    return map?.screenLocationFromPosition(position) ?: error("Map requested before it was initialized")
   }
 
   public fun queryRenderedFeatures(offset: Offset): List<Feature> {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -10,6 +10,7 @@ import dev.sargunv.maplibrecompose.core.MaplibreMap
 import dev.sargunv.maplibrecompose.core.camera.CameraPosition
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import io.github.dellisd.spatialk.geojson.Feature
+import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.channels.Channel
@@ -48,6 +49,10 @@ public class CameraState internal constructor(firstPosition: CameraPosition) {
   ) {
     val map = map ?: mapAttachSignal.receive()
     map.animateCameraPosition(finalPosition, duration)
+  }
+
+  public fun screenLocationFromPosition(position: Position): Offset? {
+    return map?.screenLocationFromPosition(position)
   }
 
   public fun queryRenderedFeatures(offset: Offset): List<Feature> {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -52,7 +52,8 @@ public class CameraState internal constructor(firstPosition: CameraPosition) {
   }
 
   public fun screenLocationFromPosition(position: Position): Offset {
-    return map?.screenLocationFromPosition(position) ?: error("Map requested before it was initialized")
+    return map?.screenLocationFromPosition(position)
+      ?: error("Map requested before it was initialized")
   }
 
   public fun queryRenderedFeatures(offset: Offset): List<Feature> {


### PR DESCRIPTION
It's useful to have access to screenLocationFromPosition outside of the library. A common use case is when someone wants to query rendered features around a certain point, they need the screen location of that point, for example:

``` kotlin
FloatingActionButton(
    onClick = {
      val position = Position(latitude = 45.521, longitude = -122.675)
      val queryCenter = cameraState.screenLocationFromPosition(position)

      queryCenter?.let {
        val queryRect = Rect(queryCenter.x - 20, queryCenter.y - 20, queryCenter.x + 20, queryCenter.y + 20)
        val result = cameraState.queryRenderedFeatures(queryRect)
      }
  })
```

By the way, what are your thoughts on pull requests without creating the issue first? Sometimes when the change is so tiny, I find it easier to make a pull request than create the issue, and you can treat it as a starting point of a discussion rather than a definitive solution. But if you prefer me to create issues first, I will keep this in mind in the future.