### PR TITLE
use compose Dp for pixel sizes

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.layer.AnchorBelow
 import dev.sargunv.maplibrecompose.compose.layer.LineLayer

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
@@ -55,7 +55,7 @@ fun AnimatedLayerDemo() = Column {
         id = "amtrak-routes",
         source = routeSource,
         color = const(animatedColor),
-        width = const(4f),
+        width = const(4.dp),
       )
     }
   }

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
@@ -22,8 +22,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.CameraState
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
@@ -64,12 +64,12 @@ private fun animateTestPosition(start: Position, end: Position): State<Position>
     end,
     typeConverter = remember { PositionVectorConverter(origin = START_POINT) },
     animationSpec =
-      remember {
-        infiniteRepeatable(
-          animation = tween(durationMillis = 30_000),
-          repeatMode = RepeatMode.Reverse,
-        )
-      },
+    remember {
+      infiniteRepeatable(
+        animation = tween(durationMillis = 30_000),
+        repeatMode = RepeatMode.Reverse,
+      )
+    },
   )
 }
 
@@ -96,19 +96,19 @@ private fun LocationPuck(locationSource: Source) {
   CircleLayer(
     id = "target-shadow",
     source = locationSource,
-    radius = const(13f),
+    radius = const(13.dp),
     color = const(Color.Black),
     blur = const(1f),
-    translate = const(Offset(0f, 1f)),
+    translate = const(DpOffset(0.dp, 1.dp)),
   )
 
   CircleLayer(
     id = "target-circle",
     source = locationSource,
-    radius = const(7f),
+    radius = const(7.dp),
     color = const(MaterialTheme.colorScheme.primary),
     strokeColor = const(Color.White),
-    strokeWidth = const(3f),
+    strokeWidth = const(3.dp),
   )
 }
 

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
@@ -64,12 +64,12 @@ private fun animateTestPosition(start: Position, end: Position): State<Position>
     end,
     typeConverter = remember { PositionVectorConverter(origin = START_POINT) },
     animationSpec =
-    remember {
-      infiniteRepeatable(
-        animation = tween(durationMillis = 30_000),
-        repeatMode = RepeatMode.Reverse,
-      )
-    },
+      remember {
+        infiniteRepeatable(
+          animation = tween(durationMillis = 30_000),
+          repeatMode = RepeatMode.Reverse,
+        )
+      },
   )
 }
 

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
@@ -106,7 +105,7 @@ fun ClusteredPointsDemo() = Column {
       filter = !has(const("point_count")),
       radius = const(13.dp),
       color = const(Color.Black),
-      blur = const(1.0),
+      blur = const(1f),
       translate = const(DpOffset(0.dp, 1.dp)),
     )
 

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.ClickResult
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.layer.CircleLayer
@@ -67,12 +69,12 @@ fun ClusteredPointsDemo() = Column {
       radius =
         step(
           input = get(const("point_count")),
-          fallback = const(15f),
-          25 to const(20f),
-          100 to const(30f),
-          500 to const(40f),
-          1000 to const(50f),
-          5000 to const(60f),
+          fallback = const(15.dp),
+          25 to const(20.dp),
+          100 to const(30.dp),
+          500 to const(40.dp),
+          1000 to const(50.dp),
+          5000 to const(60.dp),
         ),
       onClick = { features ->
         features.firstOrNull()?.geometry?.let {
@@ -102,10 +104,10 @@ fun ClusteredPointsDemo() = Column {
       id = "unclustered-bikes-shadow",
       source = bikeSource,
       filter = !has(const("point_count")),
-      radius = const(13f),
+      radius = const(13.dp),
       color = const(Color.Black),
-      blur = const(1f),
-      translate = const(Offset(0f, 1f)),
+      blur = const(1.0),
+      translate = const(DpOffset(0.dp, 1.dp)),
     )
 
     CircleLayer(
@@ -113,8 +115,8 @@ fun ClusteredPointsDemo() = Column {
       source = bikeSource,
       filter = !has(const("point_count")),
       color = const(LIME_GREEN),
-      radius = const(7f),
-      strokeWidth = const(3f),
+      radius = const(7.dp),
+      strokeWidth = const(3.dp),
       strokeColor = const(Color.White),
     )
   }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
@@ -1,16 +1,17 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.CirclePitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.CirclePitchScale
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.util.toMLNExpression
+import org.maplibre.android.style.layers.PropertyFactory
 import org.maplibre.android.style.expressions.Expression as MLNExpression
 import org.maplibre.android.style.layers.CircleLayer as MLNCircleLayer
-import org.maplibre.android.style.layers.PropertyFactory
 
 @PublishedApi
 internal actual class CircleLayer actual constructor(id: String, source: Source) :
@@ -27,7 +28,7 @@ internal actual class CircleLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.circleSortKey(sortKey.toMLNExpression()))
   }
 
-  actual fun setCircleRadius(radius: Expression<Number>) {
+  actual fun setCircleRadius(radius: Expression<Dp>) {
     impl.setProperties(PropertyFactory.circleRadius(radius.toMLNExpression()))
   }
 
@@ -43,7 +44,7 @@ internal actual class CircleLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.circleOpacity(opacity.toMLNExpression()))
   }
 
-  actual fun setCircleTranslate(translate: Expression<Offset>) {
+  actual fun setCircleTranslate(translate: Expression<DpOffset>) {
     impl.setProperties(PropertyFactory.circleTranslate(translate.toMLNExpression()))
   }
 
@@ -59,7 +60,7 @@ internal actual class CircleLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.circlePitchAlignment(pitchAlignment.toMLNExpression()))
   }
 
-  actual fun setCircleStrokeWidth(strokeWidth: Expression<Number>) {
+  actual fun setCircleStrokeWidth(strokeWidth: Expression<Dp>) {
     impl.setProperties(PropertyFactory.circleStrokeWidth(strokeWidth.toMLNExpression()))
   }
 

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
@@ -9,9 +9,9 @@ import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.util.toMLNExpression
-import org.maplibre.android.style.layers.PropertyFactory
 import org.maplibre.android.style.expressions.Expression as MLNExpression
 import org.maplibre.android.style.layers.CircleLayer as MLNCircleLayer
+import org.maplibre.android.style.layers.PropertyFactory
 
 @PublishedApi
 internal actual class CircleLayer actual constructor(id: String, source: Source) :

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
@@ -2,6 +2,7 @@ package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
@@ -30,7 +31,7 @@ internal actual class FillExtrusionLayer actual constructor(id: String, source: 
     impl.setProperties(PropertyFactory.fillExtrusionColor(color.toMLNExpression()))
   }
 
-  actual fun setFillExtrusionTranslate(translate: Expression<Offset>) {
+  actual fun setFillExtrusionTranslate(translate: Expression<DpOffset>) {
     impl.setProperties(PropertyFactory.fillExtrusionTranslate(translate.toMLNExpression()))
   }
 

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.Expression

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
@@ -2,6 +2,7 @@ package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
@@ -42,7 +43,7 @@ internal actual class FillLayer actual constructor(id: String, source: Source) :
     impl.setProperties(PropertyFactory.fillOutlineColor(outlineColor.toMLNExpression()))
   }
 
-  actual fun setFillTranslate(translate: Expression<Offset>) {
+  actual fun setFillTranslate(translate: Expression<DpOffset>) {
     impl.setProperties(PropertyFactory.fillTranslate(translate.toMLNExpression()))
   }
 

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.Expression

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/HeatmapLayer.kt
@@ -1,6 +1,7 @@
 package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.util.toMLNExpression
@@ -19,7 +20,7 @@ internal actual class HeatmapLayer actual constructor(id: String, source: Source
     impl.setFilter(filter.toMLNExpression() ?: MLNExpression.literal(true))
   }
 
-  actual fun setHeatmapRadius(radius: Expression<Number>) {
+  actual fun setHeatmapRadius(radius: Expression<Dp>) {
     impl.setProperties(PropertyFactory.heatmapRadius(radius.toMLNExpression()))
   }
 

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
@@ -10,9 +10,9 @@ import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.util.toMLNExpression
-import org.maplibre.android.style.layers.PropertyFactory
 import org.maplibre.android.style.expressions.Expression as MLNExpression
 import org.maplibre.android.style.layers.LineLayer as MLNLineLayer
+import org.maplibre.android.style.layers.PropertyFactory
 
 @PublishedApi
 internal actual class LineLayer actual constructor(id: String, source: Source) :

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
@@ -1,7 +1,8 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.LineCap
 import dev.sargunv.maplibrecompose.core.expression.LineJoin
@@ -9,9 +10,9 @@ import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.util.toMLNExpression
+import org.maplibre.android.style.layers.PropertyFactory
 import org.maplibre.android.style.expressions.Expression as MLNExpression
 import org.maplibre.android.style.layers.LineLayer as MLNLineLayer
-import org.maplibre.android.style.layers.PropertyFactory
 
 @PublishedApi
 internal actual class LineLayer actual constructor(id: String, source: Source) :
@@ -53,7 +54,7 @@ internal actual class LineLayer actual constructor(id: String, source: Source) :
     impl.setProperties(PropertyFactory.lineColor(color.toMLNExpression()))
   }
 
-  actual fun setLineTranslate(translate: Expression<Offset>) {
+  actual fun setLineTranslate(translate: Expression<DpOffset>) {
     impl.setProperties(PropertyFactory.lineTranslate(translate.toMLNExpression()))
   }
 
@@ -61,19 +62,19 @@ internal actual class LineLayer actual constructor(id: String, source: Source) :
     impl.setProperties(PropertyFactory.lineTranslateAnchor(translateAnchor.toMLNExpression()))
   }
 
-  actual fun setLineWidth(width: Expression<Number>) {
+  actual fun setLineWidth(width: Expression<Dp>) {
     impl.setProperties(PropertyFactory.lineWidth(width.toMLNExpression()))
   }
 
-  actual fun setLineGapWidth(gapWidth: Expression<Number>) {
+  actual fun setLineGapWidth(gapWidth: Expression<Dp>) {
     impl.setProperties(PropertyFactory.lineGapWidth(gapWidth.toMLNExpression()))
   }
 
-  actual fun setLineOffset(offset: Expression<Number>) {
+  actual fun setLineOffset(offset: Expression<Dp>) {
     impl.setProperties(PropertyFactory.lineOffset(offset.toMLNExpression()))
   }
 
-  actual fun setLineBlur(blur: Expression<Number>) {
+  actual fun setLineBlur(blur: Expression<Dp>) {
     impl.setProperties(PropertyFactory.lineBlur(blur.toMLNExpression()))
   }
 

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -1,8 +1,11 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.IconPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.IconRotationAlignment
@@ -39,7 +42,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.symbolPlacement(placement.toMLNExpression()))
   }
 
-  actual fun setSymbolSpacing(spacing: Expression<Number>) {
+  actual fun setSymbolSpacing(spacing: Expression<Dp>) {
     impl.setProperties(PropertyFactory.symbolSpacing(spacing.toMLNExpression()))
   }
 
@@ -96,7 +99,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.iconRotate(rotate.toMLNExpression()))
   }
 
-  actual fun setIconPadding(padding: Expression<Number>) {
+  actual fun setIconPadding(padding: Expression<Dp>) {
     impl.setProperties(PropertyFactory.iconPadding(padding.toMLNExpression()))
   }
 
@@ -104,7 +107,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.iconKeepUpright(keepUpright.toMLNExpression()))
   }
 
-  actual fun setIconOffset(offset: Expression<Offset>) {
+  actual fun setIconOffset(offset: Expression<DpOffset>) {
     impl.setProperties(PropertyFactory.iconOffset(offset.toMLNExpression()))
   }
 
@@ -128,15 +131,15 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.iconHaloColor(haloColor.toMLNExpression()))
   }
 
-  actual fun setIconHaloWidth(haloWidth: Expression<Number>) {
+  actual fun setIconHaloWidth(haloWidth: Expression<Dp>) {
     impl.setProperties(PropertyFactory.iconHaloWidth(haloWidth.toMLNExpression()))
   }
 
-  actual fun setIconHaloBlur(haloBlur: Expression<Number>) {
+  actual fun setIconHaloBlur(haloBlur: Expression<Dp>) {
     impl.setProperties(PropertyFactory.iconHaloBlur(haloBlur.toMLNExpression()))
   }
 
-  actual fun setIconTranslate(translate: Expression<Offset>) {
+  actual fun setIconTranslate(translate: Expression<DpOffset>) {
     impl.setProperties(PropertyFactory.iconTranslate(translate.toMLNExpression()))
   }
 
@@ -160,7 +163,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.textFont(font.toMLNExpression()))
   }
 
-  actual fun setTextSize(size: Expression<Number>) {
+  actual fun setTextSize(size: Expression<Dp>) {
     impl.setProperties(PropertyFactory.textSize(size.toMLNExpression()))
   }
 
@@ -212,7 +215,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.textRotate(rotate.toMLNExpression()))
   }
 
-  actual fun setTextPadding(padding: Expression<Number>) {
+  actual fun setTextPadding(padding: Expression<Dp>) {
     impl.setProperties(PropertyFactory.textPadding(padding.toMLNExpression()))
   }
 
@@ -257,15 +260,15 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.textHaloColor(haloColor.toMLNExpression()))
   }
 
-  actual fun setTextHaloWidth(haloWidth: Expression<Number>) {
+  actual fun setTextHaloWidth(haloWidth: Expression<Dp>) {
     impl.setProperties(PropertyFactory.textHaloWidth(haloWidth.toMLNExpression()))
   }
 
-  actual fun setTextHaloBlur(haloBlur: Expression<Number>) {
+  actual fun setTextHaloBlur(haloBlur: Expression<Dp>) {
     impl.setProperties(PropertyFactory.textHaloBlur(haloBlur.toMLNExpression()))
   }
 
-  actual fun setTextTranslate(translate: Expression<Offset>) {
+  actual fun setTextTranslate(translate: Expression<DpOffset>) {
     impl.setProperties(PropertyFactory.textTranslate(translate.toMLNExpression()))
   }
 

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -1,11 +1,10 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.DpRect
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.IconPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.IconRotationAlignment

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -8,9 +8,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import com.google.gson.JsonArray
@@ -68,10 +69,10 @@ private fun normalizeJsonLike(value: Any?): JsonElement =
       JsonObject().apply { value.forEach { add(it.key as String, normalizeJsonLike(it.value)) } }
 
     is Offset ->
-      JsonArray().apply {
+      JsonArray(2).apply {
         add("literal")
         add(
-          JsonArray().apply {
+          JsonArray(2).apply {
             add(value.x)
             add(value.y)
           }
@@ -79,10 +80,10 @@ private fun normalizeJsonLike(value: Any?): JsonElement =
       }
 
     is PaddingValues.Absolute ->
-      JsonArray().apply {
+      JsonArray(2).apply {
         add("literal")
         add(
-          JsonArray().apply {
+          JsonArray(4).apply {
             add(value.calculateTopPadding().value)
             add(value.calculateRightPadding(LayoutDirection.Ltr).value)
             add(value.calculateBottomPadding().value)

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -8,10 +8,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import com.google.gson.JsonArray

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/CircleLayer.kt
@@ -4,14 +4,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key as composeKey
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.core.expression.CirclePitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.CirclePitchScale
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.nil
-import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.layer.CircleLayer
+import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
 
 /**
@@ -41,11 +44,10 @@ import dev.sargunv.maplibrecompose.core.source.Source
  * @param color Circles fill color.
  * @param blur Amount to blur the circle. A value of `1` blurs the circle such that only the
  *   centerpoint has full opacity.
- * @param radius Circles radius in dp. A value in range `[0..infinity)`.
+ * @param radius Circles radius.
  * @param strokeOpacity Opacity of the circles' stroke.
  * @param strokeColor Circles' stroke color.
- * @param strokeWidth Thickness of the circles' stroke in dp. Strokes are placed outside of the
- *   [radius]. A value in range `[0..infinity)`.
+ * @param strokeWidth Thickness of the circles' stroke. Strokes are placed outside of the [radius].
  * @param pitchScale Scaling behavior of circles when the map is pitched.
  * @param pitchAlignment Orientation of circles when the map is pitched.
  * @param onClick Function to call when any feature in this layer has been clicked.
@@ -62,15 +64,15 @@ public inline fun CircleLayer(
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
   sortKey: Expression<Number> = nil(),
-  translate: Expression<Offset> = const(Offset.Zero),
+  translate: Expression<DpOffset> = const(DpOffset.Zero),
   translateAnchor: Expression<TranslateAnchor> = const(TranslateAnchor.Map),
   opacity: Expression<Number> = const(1f),
   color: Expression<Color> = const(Color.Black),
   blur: Expression<Number> = const(0f),
-  radius: Expression<Number> = const(5f),
+  radius: Expression<Dp> = const(5.dp),
   strokeOpacity: Expression<Number> = const(1f),
   strokeColor: Expression<Color> = const(Color.Black),
-  strokeWidth: Expression<Number> = const(0f),
+  strokeWidth: Expression<Dp> = const(0.dp),
   pitchScale: Expression<CirclePitchScale> = const(CirclePitchScale.Map),
   pitchAlignment: Expression<CirclePitchAlignment> = const(CirclePitchAlignment.Viewport),
   noinline onClick: FeaturesClickHandler? = null,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/CircleLayer.kt
@@ -2,7 +2,6 @@ package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key as composeKey
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -13,8 +12,8 @@ import dev.sargunv.maplibrecompose.core.expression.CirclePitchScale
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.nil
-import dev.sargunv.maplibrecompose.core.layer.CircleLayer
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
+import dev.sargunv.maplibrecompose.core.layer.CircleLayer
 import dev.sargunv.maplibrecompose.core.source.Source
 
 /**

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillExtrusionLayer.kt
@@ -2,7 +2,6 @@ package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key as composeKey
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillExtrusionLayer.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key as composeKey
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
@@ -63,7 +64,7 @@ public inline fun FillExtrusionLayer(
   maxZoom: Float = 24.0f,
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
-  translate: Expression<Offset> = const(Offset.Zero),
+  translate: Expression<DpOffset> = const(DpOffset.Zero),
   translateAnchor: Expression<TranslateAnchor> = const(TranslateAnchor.Map),
   opacity: Expression<Number> = const(1f),
   color: Expression<Color> = const(Color.Black),

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillLayer.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key as composeKey
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
@@ -63,7 +64,7 @@ public inline fun FillLayer(
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
   sortKey: Expression<Number> = nil(),
-  translate: Expression<Offset> = const(Offset.Zero),
+  translate: Expression<DpOffset> = const(DpOffset.Zero),
   translateAnchor: Expression<TranslateAnchor> = const(TranslateAnchor.Map),
   opacity: Expression<Number> = const(1f),
   color: Expression<Color> = const(Color.Black),

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillLayer.kt
@@ -2,7 +2,6 @@ package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key as composeKey
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HeatmapLayer.kt
@@ -3,6 +3,8 @@ package dev.sargunv.maplibrecompose.compose.layer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key as composeKey
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
@@ -30,8 +32,8 @@ import dev.sargunv.maplibrecompose.core.source.Source
  * @param color Defines the color of each pixel based on its density value in a heatmap. Should be
  *   an expression that uses [heatmapDensity] as input.
  * @param opacity The global opacity at which the heatmap layer will be drawn.
- * @param radius Radius of influence of one heatmap point in dp. Increasing the value makes the
- *   heatmap smoother, but less detailed. A value in the range of `[1..infinity)`.
+ * @param radius Radius of influence of one heatmap point. Increasing the value makes the heatmap
+ *   smoother, but less detailed.
  * @param weight A measure of how much an individual point contributes to the heatmap. A value of 10
  *   would be equivalent to having 10 points of weight 1 in the same spot. Especially useful when
  *   combined with clustering. A value in the range of `[0..infinity)`.
@@ -62,7 +64,7 @@ public inline fun HeatmapLayer(
       1 to const(Color(0xFFFF0000)), // red
     ),
   opacity: Expression<Number> = const(1f),
-  radius: Expression<Number> = const(30f),
+  radius: Expression<Dp> = const(30.dp), // TODO is this in pixels, or meters?
   weight: Expression<Number> = const(1f),
   intensity: Expression<Number> = const(1f),
   noinline onClick: FeaturesClickHandler? = null,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HeatmapLayer.kt
@@ -64,7 +64,7 @@ public inline fun HeatmapLayer(
       1 to const(Color(0xFFFF0000)), // red
     ),
   opacity: Expression<Number> = const(1f),
-  radius: Expression<Dp> = const(30.dp), // TODO is this in pixels, or meters?
+  radius: Expression<Dp> = const(30.dp),
   weight: Expression<Number> = const(1f),
   intensity: Expression<Number> = const(1f),
   noinline onClick: FeaturesClickHandler? = null,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/LineLayer.kt
@@ -4,13 +4,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key as composeKey
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.nil
+import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
 import dev.sargunv.maplibrecompose.core.expression.LineCap
 import dev.sargunv.maplibrecompose.core.expression.LineJoin
-import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.layer.LineLayer
 import dev.sargunv.maplibrecompose.core.source.Source
@@ -57,10 +60,10 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *
  *   Ignored if [pattern] or [dasharray] is specified.
  *
- * @param blur Blur applied to the lines, in dp. A value in range `0..infinity`.
- * @param width Thickness of the lines' stroke in dp. A value in range `[0..infinity)`.
- * @param gapWidth A value in range `[0..infinity)`. If not `0`, instead of one, two lines, each
- *   left and right of each line's actual path are drawn, with the given gap in dp in-between them.
+ * @param blur Blur applied to the lines.
+ * @param width Thickness of the lines' stroke.
+ * @param gapWidth If not `0`, instead of one, two lines, each left and right of each line's actual
+ *   path are drawn, with the given gap in-between them.
  * @param offset The lines' offset. For linear features, a positive value offsets the line to the
  *   right, relative to the direction of the line, and a negative value to the left. For polygon
  *   features, a positive value results in an inset, and a negative value results in an outset.
@@ -84,17 +87,17 @@ public inline fun LineLayer(
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
   sortKey: Expression<Number> = nil(),
-  translate: Expression<Offset> = const(Offset.Zero),
+  translate: Expression<DpOffset> = const(DpOffset.Zero),
   translateAnchor: Expression<TranslateAnchor> = const(TranslateAnchor.Map),
   opacity: Expression<Number> = const(1f),
   color: Expression<Color> = const(Color.Black),
   dasharray: Expression<List<Number>> = nil(),
   pattern: Expression<TResolvedImage> = nil(),
   gradient: Expression<Color> = nil(),
-  blur: Expression<Number> = const(0f),
-  width: Expression<Number> = const(1f),
-  gapWidth: Expression<Number> = const(0f),
-  offset: Expression<Number> = const(0f),
+  blur: Expression<Dp> = const(0.dp),
+  width: Expression<Dp> = const(1.dp),
+  gapWidth: Expression<Dp> = const(0.dp),
+  offset: Expression<Dp> = const(0.dp),
   cap: Expression<LineCap> = const(LineCap.Butt),
   join: Expression<LineJoin> = const(LineJoin.Miter),
   miterLimit: Expression<Number> = const(2f),

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/LineLayer.kt
@@ -2,7 +2,6 @@ package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key as composeKey
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -11,9 +10,9 @@ import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.nil
-import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
 import dev.sargunv.maplibrecompose.core.expression.LineCap
 import dev.sargunv.maplibrecompose.core.expression.LineJoin
+import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.layer.LineLayer
 import dev.sargunv.maplibrecompose.core.source.Source

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.core.expression.Expression
@@ -374,7 +373,7 @@ public inline fun SymbolLayer(
   iconRotationAlignment: Expression<IconRotationAlignment> = const(IconRotationAlignment.Auto),
   iconPitchAlignment: Expression<IconPitchAlignment> = const(IconPitchAlignment.Auto),
   iconTextFit: Expression<IconTextFit> = const(IconTextFit.None),
-  iconTextFitPadding: Expression<DpRect> = const(DpRect(0.dp, 0.dp, 0.dp, 0.dp)),
+  iconTextFitPadding: Expression<PaddingValues.Absolute> = const(ZeroPadding),
   iconKeepUpright: Expression<Boolean> = const(false),
   iconRotate: Expression<Number> = const(0f),
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -2,9 +2,14 @@ package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.runtime.key as composeKey
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
@@ -46,7 +51,7 @@ import dev.sargunv.maplibrecompose.core.source.Source
  * @param sortKey Sorts features within this layer in ascending order based on this value. Features
  *   with a higher sort key will appear above features with a lower sort key.
  * @param placement Symbol placement relative to its geometry.
- * @param spacing Distance between two symbol anchors in dp.
+ * @param spacing Distance between two symbol anchors.
  *
  *   Only applicable when [placement] is [SymbolPlacement.Line].
  *
@@ -75,7 +80,7 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *
  *   Ignored if [iconImage] is not specified.
  *
- * @param iconHaloBlur Fade out the halo towards the outside, in dp.
+ * @param iconHaloBlur Fade out the halo towards the outside.
  *
  *   Ignored if [iconImage] is not specified.
  *
@@ -181,7 +186,7 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textHaloBlur The halo's fadeout distance towards the outside in dp.
+ * @param textHaloBlur The halo's fadeout distance towards the outside.
  *
  *   Ignored if [textField] is not specified.
  *
@@ -189,7 +194,7 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textSize Font size in dp.
+ * @param textSize Font size.
  *
  *   Ignored if [textField] is not specified.
  *
@@ -270,9 +275,9 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textRadialOffset Radial offset of text, in the direction of the symbol's anchor. Useful in
- *   combination with [textVariableAnchor], which defaults to using the two-dimensional [textOffset]
- *   if present.
+ * @param textRadialOffset Radial offset of text in ems, in the direction of the symbol's anchor.
+ *   Useful in combination with [textVariableAnchor], which defaults to using the two-dimensional
+ *   [textOffset] if present.
  *
  *   Ignored if [textField] is not specified.
  *
@@ -290,7 +295,8 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *   When present, this property takes precedence over [textAnchor], [textVariableAnchor],
  *   [textOffset] and [textRadialOffset].
  *
- *   Example: ``` listOf( SymbolAnchor.Top to Point(0, 4), SymbolAnchor.Left to Point(3, 0),
+ *   Example: ```
+ *   listOf( SymbolAnchor.Top to Point(0, 4), SymbolAnchor.Left to Point(3, 0),
  *   SymbolAnchor.Bottom to Point(1, 1) ``` When the renderer chooses the top anchor, [0, 4] will be
  *   used for [textOffset]; the text will be shifted down by 4 ems. When the renderer chooses the
  *   left anchor, [3, 0] will be used for [textOffset]; the text will be shifted right by 3 ems.
@@ -351,7 +357,7 @@ public inline fun SymbolLayer(
   visible: Boolean = true,
   sortKey: Expression<Number> = nil(),
   placement: Expression<SymbolPlacement> = const(SymbolPlacement.Point),
-  spacing: Expression<Number> = const(250f),
+  spacing: Expression<Dp> = const(250.dp),
   avoidEdges: Expression<Boolean> = const(false),
   zOrder: Expression<SymbolZOrder> = const(SymbolZOrder.Auto),
 
@@ -362,31 +368,31 @@ public inline fun SymbolLayer(
   iconOpacity: Expression<Number> = const(1f),
   iconColor: Expression<Color> = const(Color.Black),
   iconHaloColor: Expression<Color> = const(Color.Transparent),
-  iconHaloWidth: Expression<Number> = const(0f),
-  iconHaloBlur: Expression<Number> = const(0f),
+  iconHaloWidth: Expression<Dp> = const(0.dp),
+  iconHaloBlur: Expression<Dp> = const(0.dp),
 
   // icon layout
   iconSize: Expression<Number> = const(1f),
   iconRotationAlignment: Expression<IconRotationAlignment> = const(IconRotationAlignment.Auto),
   iconPitchAlignment: Expression<IconPitchAlignment> = const(IconPitchAlignment.Auto),
   iconTextFit: Expression<IconTextFit> = const(IconTextFit.None),
-  iconTextFitPadding: Expression<PaddingValues.Absolute> = const(ZeroPadding),
+  iconTextFitPadding: Expression<DpRect> = const(DpRect(0.dp, 0.dp, 0.dp, 0.dp)),
   iconKeepUpright: Expression<Boolean> = const(false),
   iconRotate: Expression<Number> = const(0f),
 
   // icon anchoring
   iconAnchor: Expression<SymbolAnchor> = const(SymbolAnchor.Center),
-  iconOffset: Expression<Offset> = const(Offset.Zero),
+  iconOffset: Expression<DpOffset> = const(DpOffset.Zero),
 
   // icon collision
-  iconPadding: Expression<Number> = const(2f),
+  iconPadding: Expression<Dp> = const(2.dp),
   iconAllowOverlap: Expression<Boolean> = const(false),
   iconOverlap: Expression<String> = nil(),
   iconIgnorePlacement: Expression<Boolean> = const(false),
   iconOptional: Expression<Boolean> = const(false),
 
   // icon translate
-  iconTranslate: Expression<Offset> = const(Offset.Zero),
+  iconTranslate: Expression<DpOffset> = const(DpOffset.Zero),
   iconTranslateAnchor: Expression<TranslateAnchor> = const(TranslateAnchor.Map),
 
   // text content
@@ -396,13 +402,13 @@ public inline fun SymbolLayer(
   textOpacity: Expression<Number> = const(1f),
   textColor: Expression<Color> = const(Color.Black),
   textHaloColor: Expression<Color> = const(Color.Transparent),
-  textHaloWidth: Expression<Number> = const(0f),
-  textHaloBlur: Expression<Number> = const(0f),
+  textHaloWidth: Expression<Dp> = const(0.dp),
+  textHaloBlur: Expression<Dp> = const(0.dp),
 
   // text glyph properties
   textFont: Expression<List<String>> =
     literal(listOf(const("Open Sans Regular"), const("Arial Unicode MS Regular"))),
-  textSize: Expression<Number> = const(16f),
+  textSize: Expression<Dp> = const(16.dp),
   textTransform: Expression<TextTransform> = const(TextTransform.None),
   textLetterSpacing: Expression<Number> = const(0f),
   textRotationAlignment: Expression<TextRotationAlignment> = const(TextRotationAlignment.Auto),
@@ -425,14 +431,14 @@ public inline fun SymbolLayer(
   textVariableAnchorOffset: Expression<List<Pair<SymbolAnchor, Offset>>> = nil(),
 
   // text collision
-  textPadding: Expression<Number> = const(2f),
+  textPadding: Expression<Dp> = const(2.dp),
   textAllowOverlap: Expression<Boolean> = const(false),
   textOverlap: Expression<String> = nil(),
   textIgnorePlacement: Expression<Boolean> = const(false),
   textOptional: Expression<Boolean> = const(false),
 
   // text translate
-  textTranslate: Expression<Offset> = const(Offset.Zero),
+  textTranslate: Expression<DpOffset> = const(DpOffset.Zero),
   textTranslateAnchor: Expression<TranslateAnchor> = const(TranslateAnchor.Map),
   noinline onClick: FeaturesClickHandler? = null,
   noinline onLongClick: FeaturesClickHandler? = null,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -294,8 +294,7 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *   When present, this property takes precedence over [textAnchor], [textVariableAnchor],
  *   [textOffset] and [textRadialOffset].
  *
- *   Example: ```
- *   listOf( SymbolAnchor.Top to Point(0, 4), SymbolAnchor.Left to Point(3, 0),
+ *   Example: ``` listOf( SymbolAnchor.Top to Point(0, 4), SymbolAnchor.Left to Point(3, 0),
  *   SymbolAnchor.Bottom to Point(1, 1) ``` When the renderer chooses the top anchor, [0, 4] will be
  *   used for [textOffset]; the text will be shifted down by 4 ems. When the renderer chooses the
  *   left anchor, [3, 0] will be used for [textOffset]; the text will be shifted right by 3 ems.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -2,7 +2,6 @@ package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.runtime.key as composeKey
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
+import io.github.dellisd.spatialk.geojson.Geometry
 import kotlin.jvm.JvmName
 
 @Suppress("INAPPLICABLE_JVM_NAME")
@@ -388,7 +389,7 @@ public interface ExpressionScope {
   )
 
   public infix fun <Output> Expression<Boolean>.then(
-    output: Expression<Output>,
+    output: Expression<Output>
   ): CaseBranch<Output> = CaseBranch(this, output)
 
   /**
@@ -456,13 +457,12 @@ public interface ExpressionScope {
 
   @JvmName("stringsThen")
   public infix fun <Output> List<String>.then(
-    output: Expression<Output>,
-  ): MatchBranch<String, Output> =
-    MatchBranch(Expression.ofList(this.map { const(it) }), output)
+    output: Expression<Output>
+  ): MatchBranch<String, Output> = MatchBranch(Expression.ofList(this.map { const(it) }), output)
 
   @JvmName("numbersThen")
   public infix fun <Output> List<Number>.then(
-    output: Expression<Output>,
+    output: Expression<Output>
   ): MatchBranch<Number, Output> =
     MatchBranch(Expression.ofList(this.map { const(it.toFloat()) }), output)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
-import io.github.dellisd.spatialk.geojson.Geometry
 import kotlin.jvm.JvmName
 
 @Suppress("INAPPLICABLE_JVM_NAME")
@@ -389,7 +388,7 @@ public interface ExpressionScope {
   )
 
   public infix fun <Output> Expression<Boolean>.then(
-    output: Expression<Output>
+    output: Expression<Output>,
   ): CaseBranch<Output> = CaseBranch(this, output)
 
   /**
@@ -457,13 +456,13 @@ public interface ExpressionScope {
 
   @JvmName("stringsThen")
   public infix fun <Output> List<String>.then(
-    output: Expression<Output>
+    output: Expression<Output>,
   ): MatchBranch<String, Output> =
-    MatchBranch(Expression.ofList(this.map { const(it.toFloat()) }), output)
+    MatchBranch(Expression.ofList(this.map { const(it) }), output)
 
   @JvmName("numbersThen")
   public infix fun <Output> List<Number>.then(
-    output: Expression<Output>
+    output: Expression<Output>,
   ): MatchBranch<Number, Output> =
     MatchBranch(Expression.ofList(this.map { const(it.toFloat()) }), output)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
@@ -2,6 +2,8 @@ package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.CirclePitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.CirclePitchScale
 import dev.sargunv.maplibrecompose.core.expression.Expression
@@ -16,7 +18,7 @@ internal expect class CircleLayer(id: String, source: Source) : FeatureLayer {
 
   fun setCircleSortKey(sortKey: Expression<Number>)
 
-  fun setCircleRadius(radius: Expression<Number>)
+  fun setCircleRadius(radius: Expression<Dp>)
 
   fun setCircleColor(color: Expression<Color>)
 
@@ -24,7 +26,7 @@ internal expect class CircleLayer(id: String, source: Source) : FeatureLayer {
 
   fun setCircleOpacity(opacity: Expression<Number>)
 
-  fun setCircleTranslate(translate: Expression<Offset>)
+  fun setCircleTranslate(translate: Expression<DpOffset>)
 
   fun setCircleTranslateAnchor(translateAnchor: Expression<TranslateAnchor>)
 
@@ -32,7 +34,7 @@ internal expect class CircleLayer(id: String, source: Source) : FeatureLayer {
 
   fun setCirclePitchAlignment(pitchAlignment: Expression<CirclePitchAlignment>)
 
-  fun setCircleStrokeWidth(strokeWidth: Expression<Number>)
+  fun setCircleStrokeWidth(strokeWidth: Expression<Dp>)
 
   fun setCircleStrokeColor(strokeColor: Expression<Color>)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
@@ -2,6 +2,7 @@ package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
@@ -17,7 +18,7 @@ internal expect class FillExtrusionLayer(id: String, source: Source) : FeatureLa
 
   fun setFillExtrusionColor(color: Expression<Color>)
 
-  fun setFillExtrusionTranslate(translate: Expression<Offset>)
+  fun setFillExtrusionTranslate(translate: Expression<DpOffset>)
 
   fun setFillExtrusionTranslateAnchor(anchor: Expression<TranslateAnchor>)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.Expression

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
@@ -2,6 +2,7 @@ package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
@@ -23,7 +24,7 @@ internal expect class FillLayer(id: String, source: Source) : FeatureLayer {
 
   fun setFillOutlineColor(outlineColor: Expression<Color>)
 
-  fun setFillTranslate(translate: Expression<Offset>)
+  fun setFillTranslate(translate: Expression<DpOffset>)
 
   fun setFillTranslateAnchor(translateAnchor: Expression<TranslateAnchor>)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.Expression

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/HeatmapLayer.kt
@@ -1,6 +1,7 @@
 package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.source.Source
 
@@ -10,7 +11,7 @@ internal expect class HeatmapLayer(id: String, source: Source) : FeatureLayer {
 
   override fun setFilter(filter: Expression<Boolean>)
 
-  fun setHeatmapRadius(radius: Expression<Number>)
+  fun setHeatmapRadius(radius: Expression<Dp>)
 
   fun setHeatmapWeight(weight: Expression<Number>)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
@@ -2,6 +2,8 @@ package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.LineCap
 import dev.sargunv.maplibrecompose.core.expression.LineJoin
@@ -29,17 +31,17 @@ internal expect class LineLayer(id: String, source: Source) : FeatureLayer {
 
   fun setLineColor(color: Expression<Color>)
 
-  fun setLineTranslate(translate: Expression<Offset>)
+  fun setLineTranslate(translate: Expression<DpOffset>)
 
   fun setLineTranslateAnchor(translateAnchor: Expression<TranslateAnchor>)
 
-  fun setLineWidth(width: Expression<Number>)
+  fun setLineWidth(width: Expression<Dp>)
 
-  fun setLineGapWidth(gapWidth: Expression<Number>)
+  fun setLineGapWidth(gapWidth: Expression<Dp>)
 
-  fun setLineOffset(offset: Expression<Number>)
+  fun setLineOffset(offset: Expression<Dp>)
 
-  fun setLineBlur(blur: Expression<Number>)
+  fun setLineBlur(blur: Expression<Dp>)
 
   fun setLineDasharray(dasharray: Expression<List<Number>>)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -105,7 +105,9 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setTextVariableAnchor(variableAnchor: Expression<List<SymbolAnchor>>)
 
-  fun setTextVariableAnchorOffset(variableAnchorOffset: Expression<List<Pair<SymbolAnchor, Offset>>>)
+  fun setTextVariableAnchorOffset(
+    variableAnchorOffset: Expression<List<Pair<SymbolAnchor, Offset>>>
+  )
 
   fun setTextAnchor(anchor: Expression<SymbolAnchor>)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -3,6 +3,9 @@ package dev.sargunv.maplibrecompose.core.layer
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.IconPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.IconRotationAlignment
@@ -28,7 +31,7 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setSymbolPlacement(placement: Expression<SymbolPlacement>)
 
-  fun setSymbolSpacing(spacing: Expression<Number>)
+  fun setSymbolSpacing(spacing: Expression<Dp>)
 
   fun setSymbolAvoidEdges(avoidEdges: Expression<Boolean>)
 
@@ -56,11 +59,11 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setIconRotate(rotate: Expression<Number>)
 
-  fun setIconPadding(padding: Expression<Number>)
+  fun setIconPadding(padding: Expression<Dp>)
 
   fun setIconKeepUpright(keepUpright: Expression<Boolean>)
 
-  fun setIconOffset(offset: Expression<Offset>)
+  fun setIconOffset(offset: Expression<DpOffset>)
 
   fun setIconAnchor(anchor: Expression<SymbolAnchor>)
 
@@ -72,11 +75,11 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setIconHaloColor(haloColor: Expression<Color>)
 
-  fun setIconHaloWidth(haloWidth: Expression<Number>)
+  fun setIconHaloWidth(haloWidth: Expression<Dp>)
 
-  fun setIconHaloBlur(haloBlur: Expression<Number>)
+  fun setIconHaloBlur(haloBlur: Expression<Dp>)
 
-  fun setIconTranslate(translate: Expression<Offset>)
+  fun setIconTranslate(translate: Expression<DpOffset>)
 
   fun setIconTranslateAnchor(translateAnchor: Expression<TranslateAnchor>)
 
@@ -88,7 +91,7 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setTextFont(font: Expression<List<String>>)
 
-  fun setTextSize(size: Expression<Number>)
+  fun setTextSize(size: Expression<Dp>)
 
   fun setTextMaxWidth(maxWidth: Expression<Number>)
 
@@ -102,9 +105,7 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setTextVariableAnchor(variableAnchor: Expression<List<SymbolAnchor>>)
 
-  fun setTextVariableAnchorOffset(
-    variableAnchorOffset: Expression<List<Pair<SymbolAnchor, Offset>>>
-  )
+  fun setTextVariableAnchorOffset(variableAnchorOffset: Expression<List<Pair<SymbolAnchor, Offset>>>)
 
   fun setTextAnchor(anchor: Expression<SymbolAnchor>)
 
@@ -114,7 +115,7 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setTextRotate(rotate: Expression<Number>)
 
-  fun setTextPadding(padding: Expression<Number>)
+  fun setTextPadding(padding: Expression<Dp>)
 
   fun setTextKeepUpright(keepUpright: Expression<Boolean>)
 
@@ -136,11 +137,11 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setTextHaloColor(haloColor: Expression<Color>)
 
-  fun setTextHaloWidth(haloWidth: Expression<Number>)
+  fun setTextHaloWidth(haloWidth: Expression<Dp>)
 
-  fun setTextHaloBlur(haloBlur: Expression<Number>)
+  fun setTextHaloBlur(haloBlur: Expression<Dp>)
 
-  fun setTextTranslate(translate: Expression<Offset>)
+  fun setTextTranslate(translate: Expression<DpOffset>)
 
   fun setTextTranslateAnchor(translateAnchor: Expression<TranslateAnchor>)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.DpRect
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.IconPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.IconRotationAlignment

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/CircleLayer.kt
@@ -2,6 +2,8 @@ package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import cocoapods.MapLibre.MLNCircleStyleLayer
 import dev.sargunv.maplibrecompose.core.expression.CirclePitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.CirclePitchScale
@@ -31,7 +33,7 @@ internal actual class CircleLayer actual constructor(id: String, source: Source)
     impl.circleSortKey = sortKey.toNSExpression()
   }
 
-  actual fun setCircleRadius(radius: Expression<Number>) {
+  actual fun setCircleRadius(radius: Expression<Dp>) {
     impl.circleRadius = radius.toNSExpression()
   }
 
@@ -47,7 +49,7 @@ internal actual class CircleLayer actual constructor(id: String, source: Source)
     impl.circleOpacity = opacity.toNSExpression()
   }
 
-  actual fun setCircleTranslate(translate: Expression<Offset>) {
+  actual fun setCircleTranslate(translate: Expression<DpOffset>) {
     impl.circleTranslation = translate.toNSExpression()
   }
 
@@ -63,7 +65,7 @@ internal actual class CircleLayer actual constructor(id: String, source: Source)
     impl.circlePitchAlignment = pitchAlignment.toNSExpression()
   }
 
-  actual fun setCircleStrokeWidth(strokeWidth: Expression<Number>) {
+  actual fun setCircleStrokeWidth(strokeWidth: Expression<Dp>) {
     impl.circleStrokeWidth = strokeWidth.toNSExpression()
   }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
@@ -2,6 +2,7 @@ package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
 import cocoapods.MapLibre.MLNFillExtrusionStyleLayer
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
@@ -34,7 +35,7 @@ internal actual class FillExtrusionLayer actual constructor(id: String, source: 
     impl.fillExtrusionColor = color.toNSExpression()
   }
 
-  actual fun setFillExtrusionTranslate(translate: Expression<Offset>) {
+  actual fun setFillExtrusionTranslate(translate: Expression<DpOffset>) {
     impl.fillExtrusionTranslation = translate.toNSExpression()
   }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillExtrusionLayer.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import cocoapods.MapLibre.MLNFillExtrusionStyleLayer

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
@@ -2,6 +2,7 @@ package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
 import cocoapods.MapLibre.MLNFillStyleLayer
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.TResolvedImage
@@ -46,7 +47,7 @@ internal actual class FillLayer actual constructor(id: String, source: Source) :
     impl.fillOutlineColor = outlineColor.toNSExpression()
   }
 
-  actual fun setFillTranslate(translate: Expression<Offset>) {
+  actual fun setFillTranslate(translate: Expression<DpOffset>) {
     impl.fillTranslation = translate.toNSExpression()
   }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/FillLayer.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import cocoapods.MapLibre.MLNFillStyleLayer

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/HeatmapLayer.kt
@@ -1,6 +1,7 @@
 package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import cocoapods.MapLibre.MLNHeatmapStyleLayer
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.source.Source
@@ -23,7 +24,7 @@ internal actual class HeatmapLayer actual constructor(id: String, source: Source
     impl.predicate = filter.toNSPredicate()
   }
 
-  actual fun setHeatmapRadius(radius: Expression<Number>) {
+  actual fun setHeatmapRadius(radius: Expression<Dp>) {
     impl.heatmapRadius = radius.toNSExpression()
   }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
@@ -2,6 +2,8 @@ package dev.sargunv.maplibrecompose.core.layer
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import cocoapods.MapLibre.MLNLineStyleLayer
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.LineCap
@@ -56,7 +58,7 @@ internal actual class LineLayer actual constructor(id: String, source: Source) :
     impl.lineColor = color.toNSExpression()
   }
 
-  actual fun setLineTranslate(translate: Expression<Offset>) {
+  actual fun setLineTranslate(translate: Expression<DpOffset>) {
     impl.lineTranslation = translate.toNSExpression()
   }
 
@@ -64,19 +66,19 @@ internal actual class LineLayer actual constructor(id: String, source: Source) :
     impl.lineTranslationAnchor = translateAnchor.toNSExpression()
   }
 
-  actual fun setLineWidth(width: Expression<Number>) {
+  actual fun setLineWidth(width: Expression<Dp>) {
     impl.lineWidth = width.toNSExpression()
   }
 
-  actual fun setLineGapWidth(gapWidth: Expression<Number>) {
+  actual fun setLineGapWidth(gapWidth: Expression<Dp>) {
     impl.lineGapWidth = gapWidth.toNSExpression()
   }
 
-  actual fun setLineOffset(offset: Expression<Number>) {
+  actual fun setLineOffset(offset: Expression<Dp>) {
     impl.lineOffset = offset.toNSExpression()
   }
 
-  actual fun setLineBlur(blur: Expression<Number>) {
+  actual fun setLineBlur(blur: Expression<Dp>) {
     impl.lineBlur = blur.toNSExpression()
   }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/LineLayer.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -3,6 +3,9 @@ package dev.sargunv.maplibrecompose.core.layer
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
 import cocoapods.MapLibre.MLNSymbolStyleLayer
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.IconPitchAlignment
@@ -43,7 +46,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.symbolPlacement = placement.toNSExpression()
   }
 
-  actual fun setSymbolSpacing(spacing: Expression<Number>) {
+  actual fun setSymbolSpacing(spacing: Expression<Dp>) {
     impl.symbolSpacing = spacing.toNSExpression()
   }
 
@@ -101,7 +104,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.iconRotation = rotate.toNSExpression()
   }
 
-  actual fun setIconPadding(padding: Expression<Number>) {
+  actual fun setIconPadding(padding: Expression<Dp>) {
     impl.iconPadding = padding.toNSExpression()
   }
 
@@ -109,7 +112,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.keepsIconUpright = keepUpright.toNSExpression()
   }
 
-  actual fun setIconOffset(offset: Expression<Offset>) {
+  actual fun setIconOffset(offset: Expression<DpOffset>) {
     impl.iconOffset = offset.toNSExpression()
   }
 
@@ -133,15 +136,15 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.iconHaloColor = haloColor.toNSExpression()
   }
 
-  actual fun setIconHaloWidth(haloWidth: Expression<Number>) {
+  actual fun setIconHaloWidth(haloWidth: Expression<Dp>) {
     impl.iconHaloWidth = haloWidth.toNSExpression()
   }
 
-  actual fun setIconHaloBlur(haloBlur: Expression<Number>) {
+  actual fun setIconHaloBlur(haloBlur: Expression<Dp>) {
     impl.iconHaloBlur = haloBlur.toNSExpression()
   }
 
-  actual fun setIconTranslate(translate: Expression<Offset>) {
+  actual fun setIconTranslate(translate: Expression<DpOffset>) {
     impl.iconTranslation = translate.toNSExpression()
   }
 
@@ -165,7 +168,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.textFontNames = font.toNSExpression()
   }
 
-  actual fun setTextSize(size: Expression<Number>) {
+  actual fun setTextSize(size: Expression<Dp>) {
     impl.textFontSize = size.toNSExpression()
   }
 
@@ -215,7 +218,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.textRotation = rotate.toNSExpression()
   }
 
-  actual fun setTextPadding(padding: Expression<Number>) {
+  actual fun setTextPadding(padding: Expression<Dp>) {
     impl.textPadding = padding.toNSExpression()
   }
 
@@ -260,15 +263,15 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.textHaloColor = haloColor.toNSExpression()
   }
 
-  actual fun setTextHaloWidth(haloWidth: Expression<Number>) {
+  actual fun setTextHaloWidth(haloWidth: Expression<Dp>) {
     impl.textHaloWidth = haloWidth.toNSExpression()
   }
 
-  actual fun setTextHaloBlur(haloBlur: Expression<Number>) {
+  actual fun setTextHaloBlur(haloBlur: Expression<Dp>) {
     impl.textHaloBlur = haloBlur.toNSExpression()
   }
 
-  actual fun setTextTranslate(translate: Expression<Offset>) {
+  actual fun setTextTranslate(translate: Expression<DpOffset>) {
     impl.textTranslation = translate.toNSExpression()
   }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.DpRect
 import cocoapods.MapLibre.MLNSymbolStyleLayer
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.IconPitchAlignment

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -4,10 +4,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection


### PR DESCRIPTION
### I see the following advantages for this:

1. consistent with other Compose API
2. easier to see from signature which type is expected. It is often not clear from the name alone which unit is expected. E.g. `blur` in most layers is in `dp`, but in `CircleLayer`, it is actually some kind of fraction. Offsets are usually in `dp`, but any text offsets are in `em` (i.e. relative to the font size). `iconSize` is also not in `dp` but a fraction.
3. shorter documentation comments (Units don't need to be mentioned in the comments)

### Possibilities for expansion:

In the `SymbolLayer`, actually all offsets concerning text are en `em`: `textOffset`, `textRadialOffset`, `textVariableAnchorOffset` but also `texMaxWidth` and `textLineHeight`.
It would be possible to add another value class named `Em` and allow these to be created with an expression like `10.em` (like for `dp`), but this extension function actually already exists in Compose, it creates a `TextUnit`, which can be `sp` (scale-independent pixels) or `em`. So, to create a rival `val Number.em get() = Em(this)` would only confuse.
Can we use `TextUnit` instead? We could, but then we need to internally support it also when the value was specified in `sp` instead. Read: Convert it to em, for which we need the specified font size. Which we have, of course.
So, doable, but [MapLibre-native does (currently) not automatically scale fonts](https://github.com/maplibre/maplibre-native/issues/3057), i.e. the font size is specified in `dp`, not in `sp`. I think it would be confusing to be able to specify the text in `sp` but not have the font scaling working. This _could_ also be solved in this library, but I think this is rather something that should be solved upstream.

When it is solved, I'd propose to change the unit of `textSize` to `TextUnit` along with the fields mentioned above. Until then, in my opinion, it is best to leave them as `Number`s and just document that their unit are ems.