### PR TITLE
feature: migrate screen coordinates from Offset to DpOffset

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/StyleSwitcherDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/StyleSwitcherDemo.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
-import dev.sargunv.maplibrecompose.compose.ClickResult
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.rememberCameraState
 import dev.sargunv.maplibrecompose.core.camera.CameraPosition
@@ -31,13 +30,6 @@ fun StyleSwitcherDemo() = Column {
     modifier = Modifier.weight(1f),
     styleUrl = styles[selectedIndex].second,
     cameraState = cameraState,
-    onMapClick = { pos, offset ->
-      println("Clicked at $pos, $offset")
-      val gotPos = cameraState.positionFromScreenLocation(offset)
-      val gotOffset = cameraState.screenLocationFromPosition(pos)
-      println("Calculated position $gotPos, $gotOffset")
-      ClickResult.Pass
-    },
   )
 
   SecondaryScrollableTabRow(selectedTabIndex = selectedIndex) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -1,13 +1,7 @@
 package dev.sargunv.maplibrecompose.core
 
-import android.graphics.PointF
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.coerceAtLeast
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.*
 import co.touchlab.kermit.Logger
 import dev.sargunv.maplibrecompose.core.camera.CameraPosition
 import dev.sargunv.maplibrecompose.core.data.GestureSettings
@@ -165,56 +159,57 @@ internal class AndroidMap(
       )
     }
 
-  override fun positionFromScreenLocation(offset: Offset): Position =
-    map.projection.fromScreenLocation(PointF(offset.x, offset.y)).toPosition()
+  override fun positionFromScreenLocation(offset: DpOffset): Position =
+    map.projection.fromScreenLocation(offset.toPointF(density)).toPosition()
 
-  override fun screenLocationFromPosition(position: Position): Offset =
-    map.projection.toScreenLocation(position.toLatLng()).toOffset()
+  override fun screenLocationFromPosition(position: Position): DpOffset =
+    map.projection.toScreenLocation(position.toLatLng()).toOffset(density)
 
-  override fun queryRenderedFeatures(offset: Offset): List<Feature> {
-    return map.queryRenderedFeatures(offset.toPointF()).map { Feature.fromJson(it.toJson()) }
+  override fun queryRenderedFeatures(offset: DpOffset): List<Feature> {
+    return map.queryRenderedFeatures(offset.toPointF(density)).map { Feature.fromJson(it.toJson()) }
   }
 
-  override fun queryRenderedFeatures(offset: Offset, layerIds: Set<String>): List<Feature> {
-    return map.queryRenderedFeatures(offset.toPointF(), *layerIds.toTypedArray()).map {
+  override fun queryRenderedFeatures(offset: DpOffset, layerIds: Set<String>): List<Feature> {
+    return map.queryRenderedFeatures(offset.toPointF(density), *layerIds.toTypedArray()).map {
       Feature.fromJson(it.toJson())
     }
   }
 
   override fun queryRenderedFeatures(
-    offset: Offset,
+    offset: DpOffset,
     layerIds: Set<String>,
     predicate: Expression<Boolean>,
   ): List<Feature> {
     return map
       .queryRenderedFeatures(
-        offset.toPointF(),
+        offset.toPointF(density),
         predicate.toMLNExpression(),
         *layerIds.toTypedArray(),
       )
       .map { Feature.fromJson(it.toJson()) }
   }
 
-  override fun queryRenderedFeatures(rect: androidx.compose.ui.geometry.Rect): List<Feature> {
-    return map.queryRenderedFeatures(rect.toRectF()).map { Feature.fromJson(it.toJson()) }
+  override fun queryRenderedFeatures(rect: DpRect): List<Feature> {
+    return map.queryRenderedFeatures(rect.toRectF(density)).map { Feature.fromJson(it.toJson()) }
   }
 
-  override fun queryRenderedFeatures(
-    rect: androidx.compose.ui.geometry.Rect,
-    layerIds: Set<String>,
-  ): List<Feature> {
-    return map.queryRenderedFeatures(rect.toRectF(), *layerIds.toTypedArray()).map {
+  override fun queryRenderedFeatures(rect: DpRect, layerIds: Set<String>): List<Feature> {
+    return map.queryRenderedFeatures(rect.toRectF(density), *layerIds.toTypedArray()).map {
       Feature.fromJson(it.toJson())
     }
   }
 
   override fun queryRenderedFeatures(
-    rect: Rect,
+    rect: DpRect,
     layerIds: Set<String>,
     predicate: Expression<Boolean>,
   ): List<Feature> {
     return map
-      .queryRenderedFeatures(rect.toRectF(), predicate.toMLNExpression(), *layerIds.toTypedArray())
+      .queryRenderedFeatures(
+        rect.toRectF(density),
+        predicate.toMLNExpression(),
+        *layerIds.toTypedArray(),
+      )
       .map { Feature.fromJson(it.toJson()) }
   }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -4,12 +4,9 @@ import android.graphics.PointF
 import android.graphics.RectF
 import android.view.Gravity
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.*
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonNull
@@ -35,13 +32,19 @@ internal fun String.correctedAndroidUri(): URI {
   }
 }
 
-internal fun Offset.toPointF(): PointF = PointF(x, y)
+internal fun DpOffset.toPointF(density: Density): PointF =
+  with(density) { PointF(x.toPx(), y.toPx()) }
 
-internal fun PointF.toOffset(): Offset = Offset(x = x, y = y)
+internal fun PointF.toOffset(density: Density): DpOffset =
+  with(density) { DpOffset(x = x.toDp(), y = y.toDp()) }
 
-internal fun Rect.toRectF(): RectF = RectF(left, top, right, bottom)
+internal fun DpRect.toRectF(density: Density): RectF =
+  with(density) { RectF(left.toPx(), top.toPx(), right.toPx(), bottom.toPx()) }
 
-internal fun RectF.toRect(): Rect = Rect(left = left, top = top, right = right, bottom = bottom)
+internal fun RectF.toRect(density: Density): DpRect =
+  with(density) {
+    DpRect(left = left.toDp(), top = top.toDp(), right = right.toDp(), bottom = bottom.toDp())
+  }
 
 internal fun LatLng.toPosition(): Position = Position(longitude = longitude, latitude = latitude)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -4,8 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
 import dev.sargunv.maplibrecompose.core.MaplibreMap
 import dev.sargunv.maplibrecompose.core.camera.CameraPosition
 import dev.sargunv.maplibrecompose.core.expression.Expression
@@ -64,42 +64,42 @@ public class CameraState internal constructor(firstPosition: CameraPosition) {
     }
   }
 
-  public fun screenLocationFromPosition(position: Position): Offset {
+  public fun screenLocationFromPosition(position: Position): DpOffset {
     requireIsInitialized()
     return map!!.screenLocationFromPosition(position)
   }
 
-  public fun positionFromScreenLocation(offset: Offset): Position {
+  public fun positionFromScreenLocation(offset: DpOffset): Position {
     requireIsInitialized()
     return map!!.positionFromScreenLocation(offset)
   }
 
-  public fun queryRenderedFeatures(offset: Offset): List<Feature> {
+  public fun queryRenderedFeatures(offset: DpOffset): List<Feature> {
     return map?.queryRenderedFeatures(offset) ?: emptyList()
   }
 
-  public fun queryRenderedFeatures(offset: Offset, layerIds: Set<String>): List<Feature> {
+  public fun queryRenderedFeatures(offset: DpOffset, layerIds: Set<String>): List<Feature> {
     return map?.queryRenderedFeatures(offset, layerIds) ?: emptyList()
   }
 
   public fun queryRenderedFeatures(
-    offset: Offset,
+    offset: DpOffset,
     layerIds: Set<String>,
     predicate: Expression<Boolean>,
   ): List<Feature> {
     return map?.queryRenderedFeatures(offset, layerIds, predicate) ?: emptyList()
   }
 
-  public fun queryRenderedFeatures(rect: Rect): List<Feature> {
+  public fun queryRenderedFeatures(rect: DpRect): List<Feature> {
     return map?.queryRenderedFeatures(rect) ?: emptyList()
   }
 
-  public fun queryRenderedFeatures(rect: Rect, layerIds: Set<String>): List<Feature> {
+  public fun queryRenderedFeatures(rect: DpRect, layerIds: Set<String>): List<Feature> {
     return map?.queryRenderedFeatures(rect, layerIds) ?: emptyList()
   }
 
   public fun queryRenderedFeatures(
-    rect: Rect,
+    rect: DpRect,
     layerIds: Set<String>,
     predicate: Expression<Boolean>,
   ): List<Feature> {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.DpOffset
 import co.touchlab.kermit.Logger
 import dev.sargunv.maplibrecompose.compose.engine.LayerNode
 import dev.sargunv.maplibrecompose.compose.engine.rememberStyleComposition
@@ -45,7 +45,7 @@ public fun MaplibreMap(
           cameraState.positionState.value = map.cameraPosition
         }
 
-        override fun onClick(map: MaplibreMap, latLng: Position, offset: Offset) {
+        override fun onClick(map: MaplibreMap, latLng: Position, offset: DpOffset) {
           if (onMapClick(latLng, offset).consumed) return
           styleComposition
             ?.children
@@ -57,7 +57,7 @@ public fun MaplibreMap(
             }
         }
 
-        override fun onLongClick(map: MaplibreMap, latLng: Position, offset: Offset) {
+        override fun onLongClick(map: MaplibreMap, latLng: Position, offset: DpOffset) {
           if (onMapLongClick(latLng, offset).consumed) return
           styleComposition
             ?.children

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/util.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/util.kt
@@ -1,6 +1,6 @@
 package dev.sargunv.maplibrecompose.compose
 
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.DpOffset
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.Position
 
@@ -10,7 +10,7 @@ import io.github.dellisd.spatialk.geojson.Position
  * @return [ClickResult.Consume] if this click should be consumed and not passed down to layers or
  *   [ClickResult.Pass] if it should be passed down.
  */
-public typealias MapClickHandler = (Position, Offset) -> ClickResult
+public typealias MapClickHandler = (Position, DpOffset) -> ClickResult
 
 /**
  * A callback for when a feature is clicked.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
@@ -1,7 +1,7 @@
 package dev.sargunv.maplibrecompose.core
 
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
 import dev.sargunv.maplibrecompose.core.camera.CameraPosition
 import dev.sargunv.maplibrecompose.core.data.GestureSettings
 import dev.sargunv.maplibrecompose.core.data.OrnamentSettings
@@ -23,26 +23,26 @@ internal interface MaplibreMap {
 
   suspend fun animateCameraPosition(finalPosition: CameraPosition, duration: Duration)
 
-  fun positionFromScreenLocation(offset: Offset): Position
+  fun positionFromScreenLocation(offset: DpOffset): Position
 
-  fun screenLocationFromPosition(position: Position): Offset
+  fun screenLocationFromPosition(position: Position): DpOffset
 
-  fun queryRenderedFeatures(offset: Offset): List<Feature>
+  fun queryRenderedFeatures(offset: DpOffset): List<Feature>
 
-  fun queryRenderedFeatures(offset: Offset, layerIds: Set<String>): List<Feature>
+  fun queryRenderedFeatures(offset: DpOffset, layerIds: Set<String>): List<Feature>
 
   fun queryRenderedFeatures(
-    offset: Offset,
+    offset: DpOffset,
     layerIds: Set<String>,
     predicate: Expression<Boolean>,
   ): List<Feature>
 
-  fun queryRenderedFeatures(rect: Rect): List<Feature>
+  fun queryRenderedFeatures(rect: DpRect): List<Feature>
 
-  fun queryRenderedFeatures(rect: Rect, layerIds: Set<String>): List<Feature>
+  fun queryRenderedFeatures(rect: DpRect, layerIds: Set<String>): List<Feature>
 
   fun queryRenderedFeatures(
-    rect: Rect,
+    rect: DpRect,
     layerIds: Set<String>,
     predicate: Expression<Boolean>,
   ): List<Feature>
@@ -52,8 +52,8 @@ internal interface MaplibreMap {
 
     fun onCameraMove(map: MaplibreMap)
 
-    fun onClick(map: MaplibreMap, latLng: Position, offset: Offset)
+    fun onClick(map: MaplibreMap, latLng: Position, offset: DpOffset)
 
-    fun onLongClick(map: MaplibreMap, latLng: Position, offset: Offset)
+    fun onLongClick(map: MaplibreMap, latLng: Position, offset: DpOffset)
   }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -1,11 +1,7 @@
 package dev.sargunv.maplibrecompose.core
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.*
 import co.touchlab.kermit.Logger
 import cocoapods.MapLibre.MLNAltitudeForZoomLevel
 import cocoapods.MapLibre.MLNFeatureProtocol
@@ -31,10 +27,10 @@ import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.util.toCGPoint
 import dev.sargunv.maplibrecompose.core.util.toCGRect
 import dev.sargunv.maplibrecompose.core.util.toCLLocationCoordinate2D
+import dev.sargunv.maplibrecompose.core.util.toDpOffset
 import dev.sargunv.maplibrecompose.core.util.toFeature
 import dev.sargunv.maplibrecompose.core.util.toMLNOrnamentPosition
 import dev.sargunv.maplibrecompose.core.util.toNSPredicate
-import dev.sargunv.maplibrecompose.core.util.toOffset
 import dev.sargunv.maplibrecompose.core.util.toPosition
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.Position
@@ -90,12 +86,12 @@ internal class IosMap(
     addGestures(
       Gesture(UITapGestureRecognizer()) {
         if (state != UIGestureRecognizerStateEnded) return@Gesture
-        val point = locationInView(this@IosMap.mapView).toOffset(density)
+        val point = locationInView(this@IosMap.mapView).toDpOffset()
         callbacks.onClick(this@IosMap, positionFromScreenLocation(point), point)
       },
       Gesture(UILongPressGestureRecognizer()) {
         if (state != UIGestureRecognizerStateBegan) return@Gesture
-        val point = locationInView(this@IosMap.mapView).toOffset(density)
+        val point = locationInView(this@IosMap.mapView).toDpOffset()
         callbacks.onLongClick(this@IosMap, positionFromScreenLocation(point), point)
       },
     )
@@ -320,65 +316,60 @@ internal class IosMap(
       )
     }
 
-  override fun positionFromScreenLocation(offset: Offset): Position =
-    mapView
-      .convertPoint(point = offset.toCGPoint(density), toCoordinateFromView = null)
-      .toPosition()
+  override fun positionFromScreenLocation(offset: DpOffset): Position =
+    mapView.convertPoint(point = offset.toCGPoint(), toCoordinateFromView = null).toPosition()
 
-  override fun screenLocationFromPosition(position: Position): Offset =
+  override fun screenLocationFromPosition(position: Position): DpOffset =
     mapView
       .convertCoordinate(position.toCLLocationCoordinate2D(), toPointToView = null)
-      .toOffset(density)
+      .toDpOffset()
 
-  override fun queryRenderedFeatures(offset: Offset): List<Feature> {
-    return mapView.visibleFeaturesAtPoint(point = offset.toCGPoint(density)).map {
+  override fun queryRenderedFeatures(offset: DpOffset): List<Feature> {
+    return mapView.visibleFeaturesAtPoint(point = offset.toCGPoint()).map {
       (it as MLNFeatureProtocol).toFeature()
     }
   }
 
-  override fun queryRenderedFeatures(offset: Offset, layerIds: Set<String>): List<Feature> {
+  override fun queryRenderedFeatures(offset: DpOffset, layerIds: Set<String>): List<Feature> {
     return mapView
-      .visibleFeaturesAtPoint(
-        point = offset.toCGPoint(density),
-        inStyleLayersWithIdentifiers = layerIds,
-      )
+      .visibleFeaturesAtPoint(point = offset.toCGPoint(), inStyleLayersWithIdentifiers = layerIds)
       .map { (it as MLNFeatureProtocol).toFeature() }
   }
 
   override fun queryRenderedFeatures(
-    offset: Offset,
+    offset: DpOffset,
     layerIds: Set<String>,
     predicate: Expression<Boolean>,
   ): List<Feature> {
     return mapView
       .visibleFeaturesAtPoint(
-        point = offset.toCGPoint(density),
+        point = offset.toCGPoint(),
         inStyleLayersWithIdentifiers = layerIds,
         predicate = predicate.toNSPredicate(),
       )
       .map { (it as MLNFeatureProtocol).toFeature() }
   }
 
-  override fun queryRenderedFeatures(rect: Rect): List<Feature> {
-    return mapView.visibleFeaturesInRect(rect = rect.toCGRect(density)).map {
+  override fun queryRenderedFeatures(rect: DpRect): List<Feature> {
+    return mapView.visibleFeaturesInRect(rect = rect.toCGRect()).map {
       (it as MLNFeatureProtocol).toFeature()
     }
   }
 
-  override fun queryRenderedFeatures(rect: Rect, layerIds: Set<String>): List<Feature> {
+  override fun queryRenderedFeatures(rect: DpRect, layerIds: Set<String>): List<Feature> {
     return mapView
-      .visibleFeaturesInRect(rect = rect.toCGRect(density), inStyleLayersWithIdentifiers = layerIds)
+      .visibleFeaturesInRect(rect = rect.toCGRect(), inStyleLayersWithIdentifiers = layerIds)
       .map { (it as MLNFeatureProtocol).toFeature() }
   }
 
   override fun queryRenderedFeatures(
-    rect: Rect,
+    rect: DpRect,
     layerIds: Set<String>,
     predicate: Expression<Boolean>,
   ): List<Feature> {
     return mapView
       .visibleFeaturesInRect(
-        rect = rect.toCGRect(density),
+        rect = rect.toCGRect(),
         inStyleLayersWithIdentifiers = layerIds,
         predicate = predicate.toNSPredicate(),
       )

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -1,8 +1,6 @@
 package dev.sargunv.maplibrecompose.core.util
 
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.*
 import cocoapods.MapLibre.MLNFeatureProtocol
@@ -69,34 +67,27 @@ internal fun JsonElement.Companion.convert(any: Any?): JsonElement {
   }
 }
 
-internal fun CValue<CGPoint>.toOffset(density: Density): Offset = useContents {
-  Offset(x = x.toFloat(), y = y.toFloat()) * density.density
+internal fun CValue<CGPoint>.toDpOffset(): DpOffset = useContents { DpOffset(x = x.dp, y = y.dp) }
+
+internal fun DpOffset.toCGPoint(): CValue<CGPoint> =
+  CGPointMake(x = x.value.toDouble(), y = y.value.toDouble())
+
+internal fun CValue<CGRect>.toDpRect(): DpRect = useContents {
+  DpRect(
+    left = origin.x.dp,
+    top = origin.y.dp,
+    right = (origin.x + size.width).dp,
+    bottom = (origin.y + size.height).dp,
+  )
 }
 
-internal fun Offset.toCGPoint(density: Density): CValue<CGPoint> =
-  with(this / density.density) { CGPointMake(x = x.toDouble(), y = y.toDouble()) }
-
-internal fun CValue<CGRect>.toRect(density: Density): Rect =
-  with(density) {
-    useContents {
-      Rect(
-        left = origin.x.dp.toPx(),
-        top = origin.y.dp.toPx(),
-        right = (origin.x + size.width).dp.toPx(),
-        bottom = (origin.y + size.height).dp.toPx(),
-      )
-    }
-  }
-
-internal fun Rect.toCGRect(density: Density): CValue<CGRect> =
-  with(density) {
-    CGRectMake(
-      x = left.toDp().value.toDouble(),
-      y = top.toDp().value.toDouble(),
-      width = (right - left).toDp().value.toDouble(),
-      height = (bottom - top).toDp().value.toDouble(),
-    )
-  }
+internal fun DpRect.toCGRect(): CValue<CGRect> =
+  CGRectMake(
+    x = left.value.toDouble(),
+    y = top.value.toDouble(),
+    width = (right - left).value.toDouble(),
+    height = (bottom - top).value.toDouble(),
+  )
 
 internal fun CValue<CLLocationCoordinate2D>.toPosition(): Position = useContents {
   Position(longitude = longitude, latitude = latitude)


### PR DESCRIPTION
Changed screen coordinate handling from raw pixels to density-independent units (Dp).

Key changes:
- Replaced Offset with DpOffset for screen coordinates
- Replaced Rect with DpRect for screen regions
- Updated coordinate conversion utilities to handle density-independent units
- Removed debug click handling code from StyleSwitcherDemo

closes #49 
