### PR TITLE
add ability to query map for its visible region

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraStateDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraStateDemo.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastRoundToInt
+import dev.sargunv.maplibrecompose.compose.ClickResult
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.rememberCameraState
 import dev.sargunv.maplibrecompose.core.camera.CameraPosition
@@ -28,7 +29,14 @@ fun CameraStateDemo() = Column {
   val cameraState =
     rememberCameraState(firstPosition = CameraPosition(target = CHICAGO, zoom = 12.0))
 
-  MaplibreMap(modifier = Modifier.weight(1f), styleUrl = DEFAULT_STYLE, cameraState = cameraState)
+  MaplibreMap(
+    modifier = Modifier.weight(1f),
+    styleUrl = DEFAULT_STYLE,
+    cameraState = cameraState,
+    onMapClick = { _, _ ->
+      println(cameraState.queryVisibleBoundingBox())
+      ClickResult.Pass
+    })
 
   Row(modifier = Modifier.safeDrawingPadding().wrapContentSize(Alignment.Center)) {
     val pos = cameraState.position

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -7,6 +7,7 @@ import dev.sargunv.maplibrecompose.core.camera.CameraPosition
 import dev.sargunv.maplibrecompose.core.data.GestureSettings
 import dev.sargunv.maplibrecompose.core.data.OrnamentSettings
 import dev.sargunv.maplibrecompose.core.expression.Expression
+import dev.sargunv.maplibrecompose.core.util.*
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
 import dev.sargunv.maplibrecompose.core.util.toGravity
 import dev.sargunv.maplibrecompose.core.util.toLatLng
@@ -15,6 +16,7 @@ import dev.sargunv.maplibrecompose.core.util.toOffset
 import dev.sargunv.maplibrecompose.core.util.toPointF
 import dev.sargunv.maplibrecompose.core.util.toPosition
 import dev.sargunv.maplibrecompose.core.util.toRectF
+import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.coroutines.resume
@@ -74,6 +76,9 @@ internal class AndroidMap(
     set(value) {
       map.isDebugActive = value
     }
+
+  override val visibleBoundingBox: BoundingBox
+    get() = map.projection.visibleRegion.latLngBounds.toBoundingBox()
 
   override fun setMaximumFps(maximumFps: Int) = mapView.setMaximumFps(maximumFps)
 

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -53,14 +53,6 @@ internal fun Position.toLatLng(): LatLng = LatLng(latitude = latitude, longitude
 internal fun LatLngBounds.toBoundingBox(): BoundingBox =
   BoundingBox(northeast = northEast.toPosition(), southwest = southWest.toPosition())
 
-internal fun BoundingBox.toLatLngBounds(): LatLngBounds =
-  LatLngBounds.from(
-    latNorth = northeast.latitude,
-    lonEast = northeast.longitude,
-    latSouth = southwest.latitude,
-    lonWest = southwest.longitude,
-  )
-
 internal fun Expression<*>.toMLNExpression(): MLNExpression? =
   when (value) {
     null -> null

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.DpRect
 import dev.sargunv.maplibrecompose.core.MaplibreMap
 import dev.sargunv.maplibrecompose.core.camera.CameraPosition
 import dev.sargunv.maplibrecompose.core.expression.Expression
+import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration
@@ -104,5 +105,11 @@ public class CameraState internal constructor(firstPosition: CameraPosition) {
     predicate: Expression<Boolean>,
   ): List<Feature> {
     return map?.queryRenderedFeatures(rect, layerIds, predicate) ?: emptyList()
+  }
+
+  public fun queryVisibleBoundingBox(): BoundingBox {
+    // TODO at some point, this should be refactored to State, just like the camera position
+    requireIsInitialized()
+    return map!!.visibleBoundingBox
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
@@ -6,6 +6,7 @@ import dev.sargunv.maplibrecompose.core.camera.CameraPosition
 import dev.sargunv.maplibrecompose.core.data.GestureSettings
 import dev.sargunv.maplibrecompose.core.data.OrnamentSettings
 import dev.sargunv.maplibrecompose.core.expression.Expression
+import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration
@@ -14,6 +15,8 @@ internal interface MaplibreMap {
   var styleUrl: String
   var isDebugEnabled: Boolean
   var cameraPosition: CameraPosition
+
+  val visibleBoundingBox: BoundingBox
 
   fun setMaximumFps(maximumFps: Int)
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -24,6 +24,7 @@ import dev.sargunv.maplibrecompose.core.camera.CameraPosition
 import dev.sargunv.maplibrecompose.core.data.GestureSettings
 import dev.sargunv.maplibrecompose.core.data.OrnamentSettings
 import dev.sargunv.maplibrecompose.core.expression.Expression
+import dev.sargunv.maplibrecompose.core.util.toBoundingBox
 import dev.sargunv.maplibrecompose.core.util.toCGPoint
 import dev.sargunv.maplibrecompose.core.util.toCGRect
 import dev.sargunv.maplibrecompose.core.util.toCLLocationCoordinate2D
@@ -32,6 +33,7 @@ import dev.sargunv.maplibrecompose.core.util.toFeature
 import dev.sargunv.maplibrecompose.core.util.toMLNOrnamentPosition
 import dev.sargunv.maplibrecompose.core.util.toNSPredicate
 import dev.sargunv.maplibrecompose.core.util.toPosition
+import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.coroutines.resume
@@ -164,6 +166,9 @@ internal class IosMap(
         else 0uL
     }
 
+  override val visibleBoundingBox: BoundingBox
+    get() = mapView.visibleCoordinateBounds.toBoundingBox()
+
   override fun setMaximumFps(maximumFps: Int) {
     mapView.preferredFramesPerSecond = maximumFps.toLong()
   }
@@ -183,7 +188,7 @@ internal class IosMap(
       MLNOrnamentPositionTopLeft ->
         CGPointMake(
           (uiPadding.calculateLeftPadding(layoutDir).value -
-              insetPadding.calculateLeftPadding(layoutDir).value)
+            insetPadding.calculateLeftPadding(layoutDir).value)
             .toDouble()
             .coerceAtLeast(0.0) + 8.0,
           (uiPadding.calculateTopPadding().value - insetPadding.calculateTopPadding().value)
@@ -194,7 +199,7 @@ internal class IosMap(
       MLNOrnamentPositionTopRight ->
         CGPointMake(
           (uiPadding.calculateRightPadding(layoutDir).value -
-              insetPadding.calculateRightPadding(layoutDir).value)
+            insetPadding.calculateRightPadding(layoutDir).value)
             .toDouble()
             .coerceAtLeast(0.0) + 8.0,
           (uiPadding.calculateTopPadding().value - insetPadding.calculateTopPadding().value)
@@ -205,7 +210,7 @@ internal class IosMap(
       MLNOrnamentPositionBottomLeft ->
         CGPointMake(
           (uiPadding.calculateLeftPadding(layoutDir).value -
-              insetPadding.calculateLeftPadding(layoutDir).value)
+            insetPadding.calculateLeftPadding(layoutDir).value)
             .toDouble()
             .coerceAtLeast(0.0) + 8.0,
           (uiPadding.calculateBottomPadding().value - insetPadding.calculateBottomPadding().value)
@@ -216,7 +221,7 @@ internal class IosMap(
       MLNOrnamentPositionBottomRight ->
         CGPointMake(
           (uiPadding.calculateRightPadding(layoutDir).value -
-              insetPadding.calculateRightPadding(layoutDir).value)
+            insetPadding.calculateRightPadding(layoutDir).value)
             .toDouble()
             .coerceAtLeast(0.0) + 8.0,
           (uiPadding.calculateBottomPadding().value - insetPadding.calculateBottomPadding().value)
@@ -374,5 +379,11 @@ internal class IosMap(
         predicate = predicate.toNSPredicate(),
       )
       .map { (it as MLNFeatureProtocol).toFeature() }
+  }
+
+  init {
+    mapView.visibleCoordinateBounds.useContents {
+      this.ne
+    }
   }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -3,19 +3,12 @@ package dev.sargunv.maplibrecompose.core.util
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.*
-import cocoapods.MapLibre.MLNFeatureProtocol
-import cocoapods.MapLibre.MLNOrnamentPosition
-import cocoapods.MapLibre.MLNOrnamentPositionBottomLeft
-import cocoapods.MapLibre.MLNOrnamentPositionBottomRight
-import cocoapods.MapLibre.MLNOrnamentPositionTopLeft
-import cocoapods.MapLibre.MLNOrnamentPositionTopRight
-import cocoapods.MapLibre.MLNShape
-import cocoapods.MapLibre.expressionWithMLNJSONObject
-import cocoapods.MapLibre.predicateWithMLNJSONObject
+import cocoapods.MapLibre.*
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Insets
 import dev.sargunv.maplibrecompose.core.expression.Point
 import dev.sargunv.maplibrecompose.core.layer.LayerPropertyEnum
+import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.GeoJson
 import io.github.dellisd.spatialk.geojson.Position
@@ -90,14 +83,18 @@ internal fun DpRect.toCGRect(): CValue<CGRect> =
   )
 
 internal fun CValue<CLLocationCoordinate2D>.toPosition(): Position = useContents {
-  Position(longitude = longitude, latitude = latitude)
+  toPosition()
 }
+
+internal fun CLLocationCoordinate2D.toPosition(): Position =
+  Position(longitude = longitude, latitude = latitude)
 
 internal fun Position.toCLLocationCoordinate2D(): CValue<CLLocationCoordinate2D> =
   CLLocationCoordinate2DMake(latitude = latitude, longitude = longitude)
 
-internal fun DpSize.toCGSize() =
-  CGSizeMake(width = width.value.toDouble(), height = height.value.toDouble())
+internal fun CValue<MLNCoordinateBounds>.toBoundingBox(): BoundingBox = useContents {
+  BoundingBox(northeast = ne.toPosition(), southwest = sw.toPosition())
+}
 
 internal fun GeoJson.toMLNShape(): MLNShape {
   return MLNShape.shapeWithData(


### PR DESCRIPTION
Added the ability to query the visible bounding box of the map. This feature allows developers to retrieve the current visible region's coordinates through the `CameraState.queryVisibleBoundingBox()` method. The demo app has been updated to demonstrate this functionality by printing the bounding box coordinates when clicking on the map.
