### PR TITLE
convert Expression.ofNull to property as an easy win to reduce allocations

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/Expression.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/Expression.kt
@@ -15,7 +15,7 @@ public data class Expression<out T> private constructor(internal val value: Any?
 
     internal fun ofBoolean(bool: Boolean): Expression<Boolean> = Expression(bool)
 
-    internal fun ofNull(): Expression<Nothing?> = Expression(null)
+    internal val ofNull: Expression<Nothing?> = Expression(null)
 
     internal fun ofColor(color: Color): Expression<Color> = Expression(color)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -20,7 +20,7 @@ public interface ExpressionScope {
     Expression.ofLayerPropertyEnum(value)
 
   @Suppress("UNCHECKED_CAST")
-  public fun <T> nil(): Expression<T> = Expression.ofNull() as Expression<T>
+  public fun <T> nil(): Expression<T> = Expression.ofNull as Expression<T>
 
   public fun const(color: Color): Expression<Color> = Expression.ofColor(color)
 


### PR DESCRIPTION
small, easy win to help with #42 

Changed `ofNull()` function to a property `ofNull` to better reflect its constant nature, as it always returns the same `Expression<Nothing?>` instance. Updated the `nil()` function to reference the new property.
