### PR TITLE
build: enable strong skipping

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -2,6 +2,7 @@
 
 import fr.brouillard.oss.jgitver.Strategies
 import org.jetbrains.compose.ExperimentalComposeLibrary
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
@@ -114,6 +115,11 @@ kotlin {
 }
 
 compose.resources { packageOfResClass = "dev.sargunv.maplibrecompose.demoapp.generated" }
+
+composeCompiler {
+  reportsDestination = layout.buildDirectory.dir("compose/reports")
+  featureFlags = setOf(ComposeFeatureFlag.StrongSkipping)
+}
 
 spotless {
   kotlinGradle { ktfmt().googleStyle() }

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -2,6 +2,7 @@
 
 import fr.brouillard.oss.jgitver.Strategies
 import org.jetbrains.compose.ExperimentalComposeLibrary
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
@@ -121,6 +122,11 @@ kotlin {
       implementation(libs.compose.ui.test.manifest)
     }
   }
+}
+
+composeCompiler {
+  reportsDestination = layout.buildDirectory.dir("compose/reports")
+  featureFlags = setOf(ComposeFeatureFlag.StrongSkipping)
 }
 
 spotless {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -1,7 +1,6 @@
 package dev.sargunv.maplibrecompose.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.DpOffset
@@ -21,7 +20,6 @@ public fun rememberCameraState(firstPosition: CameraPosition = CameraPosition())
   return remember { CameraState(firstPosition) }
 }
 
-@Stable
 public class CameraState internal constructor(firstPosition: CameraPosition) {
   internal var map: MaplibreMap? = null
     set(map) {


### PR DESCRIPTION
* Enable the strong skipping feature flag in the Compose compiler for both the demo app and library modules.
* Enable compose compiler reports. I wanted to commit these so I could review their diffs in PRs, but they don't seem to be stable. So I put them in the build directory instead. 
* Remove the `@Stable` annotation from CameraState as it was unnecessary (there's no `equals` on it, and strong skipping is fine here)