### PR TITLE
feature: default to system refresh rate for map fps

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/FrameRateDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/FrameRateDemo.kt
@@ -13,12 +13,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
+import dev.sargunv.maplibrecompose.core.util.PlatformUtils
 import dev.sargunv.maplibrecompose.demoapp.DEFAULT_STYLE
 import kotlin.math.roundToInt
 
 @Composable
 fun FrameRateDemo() = Column {
-  var maximumFps by remember { mutableStateOf(120) }
+  val systemRefreshRate = PlatformUtils.getSystemRefreshRate().roundToInt()
+  var maximumFps by remember { mutableStateOf(systemRefreshRate) }
 
   MaplibreMap(modifier = Modifier.weight(1f), styleUrl = DEFAULT_STYLE, maximumFps = maximumFps)
 
@@ -26,8 +28,7 @@ fun FrameRateDemo() = Column {
     Slider(
       value = maximumFps.toFloat(),
       onValueChange = { maximumFps = it.roundToInt() },
-      valueRange = 15f..120f,
-      steps = 6,
+      valueRange = 15f..systemRefreshRate.toFloat(),
     )
     Text("$maximumFps", style = MaterialTheme.typography.labelMedium)
   }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/PlatformUtils.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/PlatformUtils.kt
@@ -1,0 +1,18 @@
+package dev.sargunv.maplibrecompose.core.util
+
+import android.content.Context
+import android.os.Build
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+public actual object PlatformUtils {
+  @Composable
+  public actual fun getSystemRefreshRate(): Float {
+    val context = LocalContext.current
+    val display =
+      if (Build.VERSION.SDK_INT >= 30) context.display
+      else (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+    return display?.refreshRate ?: 0f
+  }
+}

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -6,7 +6,11 @@ import android.view.Gravity
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.unit.*
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonNull

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -15,7 +15,9 @@ import dev.sargunv.maplibrecompose.core.Style
 import dev.sargunv.maplibrecompose.core.data.GestureSettings
 import dev.sargunv.maplibrecompose.core.data.OrnamentSettings
 import dev.sargunv.maplibrecompose.core.expression.ExpressionScope
+import dev.sargunv.maplibrecompose.core.util.PlatformUtils
 import io.github.dellisd.spatialk.geojson.Position
+import kotlin.math.roundToInt
 
 @Composable
 public fun MaplibreMap(
@@ -27,7 +29,7 @@ public fun MaplibreMap(
   onMapClick: MapClickHandler = { _, _ -> ClickResult.Pass },
   onMapLongClick: MapClickHandler = { _, _ -> ClickResult.Pass },
   isDebugEnabled: Boolean = false,
-  maximumFps: Int = 120, // TODO detect device native frame rate
+  maximumFps: Int = PlatformUtils.getSystemRefreshRate().roundToInt(),
   debugLogger: Logger? = remember { Logger.withTag("maplibre-compose") },
   content: @Composable ExpressionScope.() -> Unit = {},
 ) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/util/PlatformUtils.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/util/PlatformUtils.kt
@@ -1,0 +1,7 @@
+package dev.sargunv.maplibrecompose.core.util
+
+import androidx.compose.runtime.Composable
+
+public expect object PlatformUtils {
+  @Composable public fun getSystemRefreshRate(): Float
+}

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/PlatformUtils.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/PlatformUtils.kt
@@ -1,0 +1,12 @@
+package dev.sargunv.maplibrecompose.core.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.interop.LocalUIViewController
+
+public actual object PlatformUtils {
+  @Composable
+  public actual fun getSystemRefreshRate(): Float {
+    return LocalUIViewController.current.view.window?.screen?.maximumFramesPerSecond?.toFloat()
+      ?: 0f
+  }
+}

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -2,8 +2,22 @@ package dev.sargunv.maplibrecompose.core.util
 
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.*
-import cocoapods.MapLibre.*
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import cocoapods.MapLibre.MLNCoordinateBounds
+import cocoapods.MapLibre.MLNFeatureProtocol
+import cocoapods.MapLibre.MLNOrnamentPosition
+import cocoapods.MapLibre.MLNOrnamentPositionBottomLeft
+import cocoapods.MapLibre.MLNOrnamentPositionBottomRight
+import cocoapods.MapLibre.MLNOrnamentPositionTopLeft
+import cocoapods.MapLibre.MLNOrnamentPositionTopRight
+import cocoapods.MapLibre.MLNShape
+import cocoapods.MapLibre.expressionWithMLNJSONObject
+import cocoapods.MapLibre.predicateWithMLNJSONObject
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Insets
 import dev.sargunv.maplibrecompose.core.expression.Point


### PR DESCRIPTION
Detect and use system refresh rate for map rendering

This change improves frame rate handling by detecting the device's native refresh rate instead of using a hardcoded value. The maximum FPS now defaults to the system's refresh rate on both Android and iOS platforms.

Key changes:
- Added `PlatformUtils` to detect system refresh rate on Android and iOS
- Updated `FrameRateDemo` to use system refresh rate as the upper bound
- Set map's default `maximumFps` to match the system refresh rate

