### PR TITLE
feature: integrate Kermit logging with native map SDKs

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
@@ -5,7 +5,8 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.foundation.layout.Column
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import dev.sargunv.maplibrecompose.compose.MaplibreMap

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -1,14 +1,19 @@
 package dev.sargunv.maplibrecompose.core
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.ui.unit.*
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.coerceAtLeast
+import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import dev.sargunv.maplibrecompose.core.camera.CameraPosition
 import dev.sargunv.maplibrecompose.core.data.GestureSettings
 import dev.sargunv.maplibrecompose.core.data.OrnamentSettings
 import dev.sargunv.maplibrecompose.core.expression.Expression
-import dev.sargunv.maplibrecompose.core.util.*
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
+import dev.sargunv.maplibrecompose.core.util.toBoundingBox
 import dev.sargunv.maplibrecompose.core.util.toGravity
 import dev.sargunv.maplibrecompose.core.util.toLatLng
 import dev.sargunv.maplibrecompose.core.util.toMLNExpression
@@ -25,6 +30,7 @@ import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import org.maplibre.android.camera.CameraPosition as MLNCameraPosition
 import org.maplibre.android.camera.CameraUpdateFactory
+import org.maplibre.android.log.Logger as MLNLogger
 import org.maplibre.android.maps.MapLibreMap as MLNMap
 import org.maplibre.android.maps.MapLibreMap
 import org.maplibre.android.maps.MapView
@@ -36,9 +42,17 @@ internal class AndroidMap(
   internal var layoutDir: LayoutDirection,
   internal var density: Density,
   internal var callbacks: MaplibreMap.Callbacks,
-  internal var logger: Logger?,
+  logger: Logger?,
   styleUrl: String,
 ) : MaplibreMap {
+
+  internal var logger: Logger? = logger
+    set(value) {
+      if (value != field) {
+        MLNLogger.setLoggerDefinition(KermitLoggerDefinition(value))
+        field = value
+      }
+    }
 
   override var styleUrl: String = ""
     set(value) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/KermitLoggerDefinition.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/KermitLoggerDefinition.kt
@@ -1,0 +1,46 @@
+package dev.sargunv.maplibrecompose.core
+
+import co.touchlab.kermit.Logger
+import org.maplibre.android.log.LoggerDefinition
+
+internal class KermitLoggerDefinition(private val kermit: Logger?) : LoggerDefinition {
+  override fun v(tag: String, msg: String) {
+    kermit?.v(tag = tag) { msg }
+  }
+
+  override fun v(tag: String, msg: String, tr: Throwable) {
+    kermit?.v(tag = tag, throwable = tr) { msg }
+  }
+
+  override fun d(tag: String, msg: String) {
+    kermit?.d(tag = tag) { msg }
+  }
+
+  override fun d(tag: String, msg: String, tr: Throwable?) {
+    kermit?.d(tag = tag, throwable = tr) { msg }
+  }
+
+  override fun i(tag: String, msg: String) {
+    kermit?.i(tag = tag) { msg }
+  }
+
+  override fun i(tag: String, msg: String, tr: Throwable?) {
+    kermit?.i(tag = tag, throwable = tr) { msg }
+  }
+
+  override fun w(tag: String, msg: String) {
+    kermit?.w(tag = tag) { msg }
+  }
+
+  override fun w(tag: String, msg: String, tr: Throwable?) {
+    kermit?.w(tag = tag, throwable = tr) { msg }
+  }
+
+  override fun e(tag: String, msg: String) {
+    kermit?.e(tag = tag) { msg }
+  }
+
+  override fun e(tag: String, msg: String, tr: Throwable?) {
+    kermit?.e(tag = tag, throwable = tr) { msg }
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -30,11 +30,11 @@ public fun MaplibreMap(
   onMapLongClick: MapClickHandler = { _, _ -> ClickResult.Pass },
   isDebugEnabled: Boolean = false,
   maximumFps: Int = PlatformUtils.getSystemRefreshRate().roundToInt(),
-  debugLogger: Logger? = remember { Logger.withTag("maplibre-compose") },
+  logger: Logger? = remember { Logger.withTag("maplibre-compose") },
   content: @Composable ExpressionScope.() -> Unit = {},
 ) {
   var rememberedStyle by remember { mutableStateOf<Style?>(null) }
-  val styleComposition by rememberStyleComposition(rememberedStyle, debugLogger, content)
+  val styleComposition by rememberStyleComposition(rememberedStyle, logger, content)
 
   val callbacks =
     remember(cameraState, styleComposition) {
@@ -89,7 +89,7 @@ public fun MaplibreMap(
       cameraState.map = null
       rememberedStyle = null
     },
-    logger = debugLogger,
+    logger = logger,
     callbacks = callbacks,
   )
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/Expression.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/Expression.kt
@@ -22,7 +22,8 @@ public data class Expression<out T> private constructor(internal val value: Any?
     internal fun ofString(string: String): Expression<String> = Expression(string)
 
     internal fun ofNumber(number: Int): Expression<Number> =
-      if (number < constSmallInts.size) constSmallInts[number] else Expression(number)
+      if (number < constSmallInts.size && number >= 0) constSmallInts[number]
+      else Expression(number)
 
     internal fun ofNumber(number: Float): Expression<Number> = Expression(number)
 


### PR DESCRIPTION
Adds logging integration with MapLibre's native logging systems on both Android and iOS platforms. On Android, implements a `KermitLoggerDefinition` to bridge Kermit logging with MapLibre's logging system. On iOS, configures MapLibre's logging system to forward logs to Kermit. Also includes a fix for negative number handling in Expression creation.

relates to #38 but doesn't quite resolve it, as the http logger on android seems to be distinct from the LoggerDefinition configuration
