### PR TITLE
build: make maplibre dependencies api instead of implementation

### DIFF
--- a/demo-app/src/androidMain/kotlin/dev/sargunv/maplibrecompose/demoapp/MainActivity.kt
+++ b/demo-app/src/androidMain/kotlin/dev/sargunv/maplibrecompose/demoapp/MainActivity.kt
@@ -4,10 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import org.maplibre.android.module.http.HttpRequestUtil
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    HttpRequestUtil.setLogEnabled(false)
     enableEdgeToEdge()
     setContent { DemoApp() }
   }

--- a/demo-app/src/androidMain/kotlin/dev/sargunv/maplibrecompose/demoapp/MainActivity.kt
+++ b/demo-app/src/androidMain/kotlin/dev/sargunv/maplibrecompose/demoapp/MainActivity.kt
@@ -4,11 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import org.maplibre.android.MapLibre
 import org.maplibre.android.module.http.HttpRequestUtil
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    MapLibre.getInstance(this)
     HttpRequestUtil.setLogEnabled(false)
     enableEdgeToEdge()
     setContent { DemoApp() }

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -95,16 +95,16 @@ kotlin {
     }
 
     commonMain.dependencies {
-      implementation(compose.runtime)
-      implementation(compose.foundation)
+      api(compose.runtime)
+      api(compose.foundation)
       api(libs.kermit)
       api(compose.ui)
       api(libs.spatialk.geojson)
     }
 
     androidMain.dependencies {
-      implementation(libs.maplibre.android)
-      implementation(libs.maplibre.android.plugin.annotation)
+      api(libs.maplibre.android)
+      api(libs.maplibre.android.plugin.annotation)
     }
 
     commonTest.dependencies {


### PR DESCRIPTION
this'll allow a workaround for https://github.com/sargunv/maplibre-compose/issues/38 by exposing the native sdk in android sourcesets. will solve the full logging issue later
