### PR TITLE
create default vals for complex defaults, and precalculate small floats expressions in .05 increments

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/BackgroundLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/BackgroundLayer.kt
@@ -1,7 +1,7 @@
 package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
+import androidx.compose.runtime.key
 import androidx.compose.ui.graphics.Color
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
@@ -38,7 +38,7 @@ public inline fun BackgroundLayer(
   color: Expression<Color> = const(Color.Black),
   pattern: Expression<TResolvedImage> = nil(),
 ) {
-  composeKey(id) {
+  key(id) {
     LayerNode(
       factory = { BackgroundLayer(id = id) },
       update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/CircleLayer.kt
@@ -1,7 +1,7 @@
 package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
+import androidx.compose.runtime.key
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -77,7 +77,7 @@ public inline fun CircleLayer(
   noinline onClick: FeaturesClickHandler? = null,
   noinline onLongClick: FeaturesClickHandler? = null,
 ) {
-  composeKey(id) {
+  key(id) {
     LayerNode(
       factory = { CircleLayer(id = id, source = source) },
       update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillExtrusionLayer.kt
@@ -1,7 +1,7 @@
 package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
+import androidx.compose.runtime.key
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
@@ -74,7 +74,7 @@ public inline fun FillExtrusionLayer(
   noinline onClick: FeaturesClickHandler? = null,
   noinline onLongClick: FeaturesClickHandler? = null,
 ) {
-  composeKey(id) {
+  key(id) {
     LayerNode(
       factory = { FillExtrusionLayer(id = id, source = source) },
       update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillLayer.kt
@@ -1,7 +1,7 @@
 package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
+import androidx.compose.runtime.key
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
@@ -73,7 +73,7 @@ public inline fun FillLayer(
   noinline onClick: FeaturesClickHandler? = null,
   noinline onLongClick: FeaturesClickHandler? = null,
 ) {
-  composeKey(id) {
+  key(id) {
     LayerNode(
       factory = { FillLayer(id = id, source = source) },
       update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HeatmapLayer.kt
@@ -1,16 +1,15 @@
 package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
+import androidx.compose.runtime.key
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
+import dev.sargunv.maplibrecompose.core.expression.Defaults
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.heatmapDensity
-import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.interpolate
-import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.linear
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.nil
 import dev.sargunv.maplibrecompose.core.layer.HeatmapLayer
 import dev.sargunv.maplibrecompose.core.source.Source
@@ -52,17 +51,7 @@ public inline fun HeatmapLayer(
   maxZoom: Float = 24.0f,
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
-  color: Expression<Color> =
-    interpolate(
-      linear(),
-      heatmapDensity(),
-      0 to const(Color.Transparent),
-      0.1 to const(Color(0xFF4169E1)), // royal blue
-      0.3 to const(Color(0xFF00FFFF)), // cyan
-      0.5 to const(Color(0xFF00FF00)), // lime
-      0.7 to const(Color(0xFFFFFF00)), // yellow
-      1 to const(Color(0xFFFF0000)), // red
-    ),
+  color: Expression<Color> = Defaults.HeatmapColors,
   opacity: Expression<Number> = const(1f),
   radius: Expression<Dp> = const(30.dp),
   weight: Expression<Number> = const(1f),
@@ -70,7 +59,7 @@ public inline fun HeatmapLayer(
   noinline onClick: FeaturesClickHandler? = null,
   noinline onLongClick: FeaturesClickHandler? = null,
 ) {
-  composeKey(id) {
+  key(id) {
     LayerNode(
       factory = { HeatmapLayer(id = id, source = source) },
       update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HillshadeLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HillshadeLayer.kt
@@ -1,7 +1,7 @@
 package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
+import androidx.compose.runtime.key
 import androidx.compose.ui.graphics.Color
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
@@ -48,7 +48,7 @@ public inline fun HillshadeLayer(
   illuminationAnchor: Expression<IlluminationAnchor> = const(IlluminationAnchor.Viewport),
   exaggeration: Expression<Number> = const(0.5f),
 ) {
-  composeKey(id) {
+  key(id) {
     LayerNode(
       factory = { HillshadeLayer(id = id, source = source) },
       update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/LineLayer.kt
@@ -1,7 +1,7 @@
 package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
+import androidx.compose.runtime.key
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -104,7 +104,7 @@ public inline fun LineLayer(
   noinline onClick: FeaturesClickHandler? = null,
   noinline onLongClick: FeaturesClickHandler? = null,
 ) {
-  composeKey(id) {
+  key(id) {
     LayerNode(
       factory = { LineLayer(id = id, source = source) },
       update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/RasterLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/RasterLayer.kt
@@ -1,7 +1,7 @@
 package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
+import androidx.compose.runtime.key
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
 import dev.sargunv.maplibrecompose.core.expression.RasterResampling
@@ -49,7 +49,7 @@ public inline fun RasterLayer(
   resampling: Expression<RasterResampling> = const(RasterResampling.Linear),
   fadeDuration: Expression<Number> = const(300f),
 ) {
-  composeKey(id) {
+  key(id) {
     LayerNode(
       factory = { RasterLayer(id = id, source = source) },
       update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -2,16 +2,16 @@ package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
+import androidx.compose.runtime.key
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
+import dev.sargunv.maplibrecompose.core.expression.Defaults
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
-import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.literal
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.nil
 import dev.sargunv.maplibrecompose.core.expression.IconPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.IconRotationAlignment
@@ -403,8 +403,7 @@ public inline fun SymbolLayer(
   textHaloBlur: Expression<Dp> = const(0.dp),
 
   // text glyph properties
-  textFont: Expression<List<String>> =
-    literal(listOf(const("Open Sans Regular"), const("Arial Unicode MS Regular"))),
+  textFont: Expression<List<String>> = Defaults.FontNames,
   textSize: Expression<Dp> = const(16.dp),
   textTransform: Expression<TextTransform> = const(TextTransform.None),
   textLetterSpacing: Expression<Number> = const(0f),
@@ -440,7 +439,7 @@ public inline fun SymbolLayer(
   noinline onClick: FeaturesClickHandler? = null,
   noinline onLongClick: FeaturesClickHandler? = null,
 ) {
-  composeKey(id) {
+  key(id) {
     LayerNode(
       factory = { SymbolLayer(id = id, source = source) },
       update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/Expression.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/Expression.kt
@@ -13,7 +13,8 @@ import androidx.compose.ui.unit.DpOffset
 public data class Expression<out T> private constructor(internal val value: Any?) {
   public companion object : ExpressionScope {
     // instantiate some commonly used values so we're not allocating them over and over
-    private val constSmallInts = Array<Expression<Number>>(256) { Expression(it) }
+    private val constSmallInts = Array<Expression<Number>>(512) { Expression(it) }
+    private val constSmallFloats = Array<Expression<Number>>(512) { Expression(it.toFloat() / 20f) }
     private val constBlack: Expression<Color> = Expression(Color.Black)
     private val constWhite: Expression<Color> = Expression(Color.White)
     private val constTransparent: Expression<Color> = Expression(Color.Transparent)
@@ -31,7 +32,11 @@ public data class Expression<out T> private constructor(internal val value: Any?
       this >= 0 && this < constSmallInts.size && this.toInt().toFloat() == this
 
     internal fun ofFloat(float: Float): Expression<Number> {
-      return if (float.isSmallInt()) constSmallInts[float.toInt()] else Expression(float)
+      return when {
+        float.isSmallInt() -> constSmallInts[float.toInt()]
+        (float * 20f).isSmallInt() -> constSmallFloats[(float * 20f).toInt()]
+        else -> Expression(float)
+      }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/utils.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/utils.kt
@@ -1,7 +1,13 @@
 package dev.sargunv.maplibrecompose.core.expression
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
+import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.heatmapDensity
+import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.interpolate
+import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.linear
+import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.literal
 
 // token types for expression type safety; these should never be instantiated
 
@@ -13,4 +19,23 @@ public sealed interface TCollator
 
 public sealed interface TInterpolationType
 
+// helpers for default expression values
+
 public val ZeroPadding: PaddingValues.Absolute = PaddingValues.Absolute(0.dp)
+
+public object Defaults {
+  public val HeatmapColors: Expression<Color> =
+    interpolate(
+      linear(),
+      heatmapDensity(),
+      0 to const(Color.Transparent),
+      0.1 to const(Color(0xFF4169E1)), // royal blue
+      0.3 to const(Color(0xFF00FFFF)), // cyan
+      0.5 to const(Color(0xFF00FF00)), // lime
+      0.7 to const(Color(0xFFFFFF00)), // yellow
+      1 to const(Color(0xFFFF0000)), // red
+    )
+
+  public val FontNames: Expression<List<String>> =
+    literal(listOf(const("Open Sans Regular"), const("Arial Unicode MS Regular")))
+}


### PR DESCRIPTION
also eliminate some superfluous import aliases
