### PR TITLE
feat: add camera move reason tracking

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
+import dev.sargunv.maplibrecompose.core.CameraMoveReason
 import dev.sargunv.maplibrecompose.core.CameraPosition
 import dev.sargunv.maplibrecompose.core.MaplibreMap
 import dev.sargunv.maplibrecompose.core.expression.Expression
@@ -33,6 +34,7 @@ public class CameraState internal constructor(firstPosition: CameraPosition) {
   private val mapAttachSignal = Channel<MaplibreMap>()
 
   internal val positionState = mutableStateOf(firstPosition)
+  internal val moveReasonState = mutableStateOf(CameraMoveReason.NONE)
 
   // if the map is not yet initialized, we store the value to apply it later
   public var position: CameraPosition
@@ -42,8 +44,8 @@ public class CameraState internal constructor(firstPosition: CameraPosition) {
       positionState.value = value
     }
 
-  public val isInitialized: Boolean
-    get() = map != null
+  public val moveReason: CameraMoveReason
+    get() = moveReasonState.value
 
   public suspend fun awaitInitialized() {
     map ?: mapAttachSignal.receive()
@@ -58,7 +60,7 @@ public class CameraState internal constructor(firstPosition: CameraPosition) {
   }
 
   private fun requireIsInitialized() {
-    require(isInitialized) {
+    require(map != null) {
       "Map requested before it was initialized; try calling awaitInitialization() first"
     }
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.DpOffset
 import co.touchlab.kermit.Logger
 import dev.sargunv.maplibrecompose.compose.engine.LayerNode
 import dev.sargunv.maplibrecompose.compose.engine.rememberStyleComposition
+import dev.sargunv.maplibrecompose.core.CameraMoveReason
 import dev.sargunv.maplibrecompose.core.GestureSettings
 import dev.sargunv.maplibrecompose.core.MaplibreMap
 import dev.sargunv.maplibrecompose.core.OrnamentSettings
@@ -44,9 +45,15 @@ public fun MaplibreMap(
           rememberedStyle = style
         }
 
-        override fun onCameraMove(map: MaplibreMap) {
+        override fun onCameraMoveStarted(map: MaplibreMap, reason: CameraMoveReason) {
+          cameraState.moveReasonState.value = reason
+        }
+
+        override fun onCameraMoved(map: MaplibreMap) {
           cameraState.positionState.value = map.cameraPosition
         }
+
+        override fun onCameraMoveEnded(map: MaplibreMap) {}
 
         override fun onClick(map: MaplibreMap, latLng: Position, offset: DpOffset) {
           if (onMapClick(latLng, offset).consumed) return

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraMoveReason.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraMoveReason.kt
@@ -1,0 +1,18 @@
+package dev.sargunv.maplibrecompose.core
+
+public enum class CameraMoveReason {
+  /** The camera hasn't moved yet. */
+  NONE,
+
+  /** The camera moved for a reason we don't understand. File a bug report! */
+  UNKNOWN,
+
+  /**
+   * Camera movement was initiated by the user manipulating the map by panning, zooming, rotating,
+   * or tilting.
+   */
+  GESTURE,
+
+  /** Camera movement was initiated by a call to the public API, or by the compass ornament. */
+  PROGRAMMATIC,
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
@@ -51,7 +51,11 @@ internal interface MaplibreMap {
   interface Callbacks {
     fun onStyleChanged(map: MaplibreMap, style: Style?)
 
-    fun onCameraMove(map: MaplibreMap)
+    fun onCameraMoveStarted(map: MaplibreMap, reason: CameraMoveReason)
+
+    fun onCameraMoved(map: MaplibreMap)
+
+    fun onCameraMoveEnded(map: MaplibreMap)
 
     fun onClick(map: MaplibreMap, latLng: Position, offset: DpOffset)
 


### PR DESCRIPTION
Added camera movement tracking to improve map interaction. To showcase this, in the camera follow demo, the camera now stops following when users interact with the map through gestures like panning, zooming, rotating, or tilting. Users can resume following with a new "Follow" button.

closes #12 

