### PR TITLE
document some settings

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -177,6 +177,11 @@ internal class AndroidMap(
     map.uiSettings.isScrollGesturesEnabled = value.isScrollGesturesEnabled
     map.uiSettings.isTiltGesturesEnabled = value.isTiltGesturesEnabled
     map.uiSettings.isZoomGesturesEnabled = value.isZoomGesturesEnabled
+    // on iOS, there is no setting for enabling quick zoom (=double-tap, hold and move up or down)
+    // and zoom in by a double tap separately, so isZoomGesturesEnabled turns on or off ALL zoom
+    // gestures
+    map.uiSettings.isQuickZoomGesturesEnabled = value.isZoomGesturesEnabled
+    map.uiSettings.isDoubleTapGesturesEnabled = value.isZoomGesturesEnabled
   }
 
   override fun setOrnamentSettings(value: OrnamentSettings) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -20,6 +20,7 @@ public actual class GeoJsonSource : Source {
 
   private fun buildOptionMap(options: GeoJsonOptions) =
     MLNGeoJsonOptions().apply {
+      withMinZoom(options.minZoom)
       withMaxZoom(options.maxZoom)
       withBuffer(options.buffer)
       withTolerance(options.tolerance)

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -24,8 +24,8 @@ import kotlin.math.roundToInt
 public fun MaplibreMap(
   modifier: Modifier = Modifier,
   styleUrl: String = "https://demotiles.maplibre.org/style.json",
-  gestureSettings: GestureSettings = GestureSettings(),
-  ornamentSettings: OrnamentSettings = OrnamentSettings(),
+  gestureSettings: GestureSettings = GestureSettings.AllEnabled,
+  ornamentSettings: OrnamentSettings = OrnamentSettings.AllEnabled,
   cameraState: CameraState = rememberCameraState(),
   onMapClick: MapClickHandler = { _, _ -> ClickResult.Pass },
   onMapLongClick: MapClickHandler = { _, _ -> ClickResult.Pass },

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraMoveReason.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraMoveReason.kt
@@ -1,5 +1,8 @@
 package dev.sargunv.maplibrecompose.core
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 public enum class CameraMoveReason {
   /** The camera hasn't moved yet. */
   NONE,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraPosition.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraPosition.kt
@@ -5,6 +5,20 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.dp
 import io.github.dellisd.spatialk.geojson.Position
 
+/**
+ * Defines how the camera is oriented towards the map.
+ *
+ * @param bearing Direction that the camera is pointing in, in degrees clockwise from north.
+ * @param target Target position to align with the center of the screen, i.e. where the camera
+ *   is pointing at.
+ * @param tilt The camera angle, in degrees, from the nadir (directly down). A value in the range of
+ *   `[0 .. 60]`
+ * @param zoom Zoom level at target. A value in the range of `[0 .. 25.5]`
+ * @param padding By default, the camera points at the center of the screen, i.e. it also rotates
+ *   and tilts around that point. By specifying a padding, this center point can be altered, for
+ *   example if you want to display a bottom sheet above the lower part of the map, focussing on
+ *   a POI in the upper part of the map.
+ */
 @Immutable
 public data class CameraPosition(
   public val bearing: Double = 0.0,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraPosition.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraPosition.kt
@@ -1,7 +1,7 @@
 package dev.sargunv.maplibrecompose.core
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.unit.dp
 import io.github.dellisd.spatialk.geojson.Position
 
@@ -19,7 +19,7 @@ import io.github.dellisd.spatialk.geojson.Position
  *   example if you want to display a bottom sheet above the lower part of the map, focussing on a
  *   POI in the upper part of the map.
  */
-@Immutable
+@Stable
 public data class CameraPosition(
   public val bearing: Double = 0.0,
   public val target: Position = Position(0.0, 0.0),

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraPosition.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraPosition.kt
@@ -19,7 +19,7 @@ import io.github.dellisd.spatialk.geojson.Position
  *   example if you want to display a bottom sheet above the lower part of the map, focussing on a
  *   POI in the upper part of the map.
  */
-@Stable
+@Stable // not @Immutable because of PaddingValues
 public data class CameraPosition(
   public val bearing: Double = 0.0,
   public val target: Position = Position(0.0, 0.0),

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraPosition.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/CameraPosition.kt
@@ -9,15 +9,15 @@ import io.github.dellisd.spatialk.geojson.Position
  * Defines how the camera is oriented towards the map.
  *
  * @param bearing Direction that the camera is pointing in, in degrees clockwise from north.
- * @param target Target position to align with the center of the screen, i.e. where the camera
- *   is pointing at.
+ * @param target Target position to align with the center of the screen, i.e. where the camera is
+ *   pointing at.
  * @param tilt The camera angle, in degrees, from the nadir (directly down). A value in the range of
  *   `[0 .. 60]`
  * @param zoom Zoom level at target. A value in the range of `[0 .. 25.5]`
  * @param padding By default, the camera points at the center of the screen, i.e. it also rotates
  *   and tilts around that point. By specifying a padding, this center point can be altered, for
- *   example if you want to display a bottom sheet above the lower part of the map, focussing on
- *   a POI in the upper part of the map.
+ *   example if you want to display a bottom sheet above the lower part of the map, focussing on a
+ *   POI in the upper part of the map.
  */
 @Immutable
 public data class CameraPosition(

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/GestureSettings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/GestureSettings.kt
@@ -1,8 +1,28 @@
 package dev.sargunv.maplibrecompose.core
 
+import androidx.compose.runtime.Immutable
+
+/**
+ *  Defines which user map gestures are enabled
+ *
+ *  @param isTiltGesturesEnabled whether user may tilt (pitch) the map by vertically dragging two
+ *    fingers up or down
+ *  @param isZoomGesturesEnabled whether user may zoom the map in and out by pinching two fingers or
+ *    by double tapping, holding, and moving the finger up and down as well as simply double tapping
+ *    to zoom in
+ *  @param isRotateGesturesEnabled whether user may rotate the map by moving two fingers in a
+ *    circular motion
+ *  @param isScrollGesturesEnabled whether user may scroll the map by dragging or swiping with one
+ *    finger
+ *  */
+@Immutable
 public data class GestureSettings(
   val isTiltGesturesEnabled: Boolean = true,
   val isZoomGesturesEnabled: Boolean = true,
   val isRotateGesturesEnabled: Boolean = true,
   val isScrollGesturesEnabled: Boolean = true,
-)
+) {
+  public companion object {
+    public val AllEnabled: GestureSettings = GestureSettings()
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/GestureSettings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/GestureSettings.kt
@@ -3,18 +3,18 @@ package dev.sargunv.maplibrecompose.core
 import androidx.compose.runtime.Immutable
 
 /**
- *  Defines which user map gestures are enabled
+ * Defines which user map gestures are enabled
  *
- *  @param isTiltGesturesEnabled whether user may tilt (pitch) the map by vertically dragging two
- *    fingers up or down
- *  @param isZoomGesturesEnabled whether user may zoom the map in and out by pinching two fingers or
- *    by double tapping, holding, and moving the finger up and down as well as simply double tapping
- *    to zoom in
- *  @param isRotateGesturesEnabled whether user may rotate the map by moving two fingers in a
- *    circular motion
- *  @param isScrollGesturesEnabled whether user may scroll the map by dragging or swiping with one
- *    finger
- *  */
+ * @param isTiltGesturesEnabled whether user may tilt (pitch) the map by vertically dragging two
+ *   fingers up or down
+ * @param isZoomGesturesEnabled whether user may zoom the map in and out by pinching two fingers or
+ *   by double tapping, holding, and moving the finger up and down as well as simply double tapping
+ *   to zoom in
+ * @param isRotateGesturesEnabled whether user may rotate the map by moving two fingers in a
+ *   circular motion
+ * @param isScrollGesturesEnabled whether user may scroll the map by dragging or swiping with one
+ *   finger
+ */
 @Immutable
 public data class GestureSettings(
   val isTiltGesturesEnabled: Boolean = true,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/OrnamentSettings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/OrnamentSettings.kt
@@ -6,20 +6,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 
 /**
- *  Defines which additional UI elements are displayed on top of the map.
+ * Defines which additional UI elements are displayed on top of the map.
  *
- *  @param padding padding of the ornaments to the edge of the map
- *  @param isLogoEnabled whether to display the MapLibre logo
- *  @param logoAlignment where to place the MapLibre logo
- *  @param isAttributionEnabled whether to display copyright attribution information. If `true`,
- *    all attribution for all sources used is displayed. If there is not enough space to
- *    conveniently display those, a small button in the shape of an ⓘ will be displayed instead.
- *    Tapping on it opens the attribution information in a dialog.
- *  @param attributionAlignment where to place the attribution information
- *  @param isCompassEnabled whether to display a compass that shows which direction is north.
- *    Tapping on the compass will reset the camera rotations to zero.
- *  @param compassAlignment where to place the compass
- * */
+ * @param padding padding of the ornaments to the edge of the map
+ * @param isLogoEnabled whether to display the MapLibre logo
+ * @param logoAlignment where to place the MapLibre logo
+ * @param isAttributionEnabled whether to display copyright attribution information. If `true`, all
+ *   attribution for all sources used is displayed. If there is not enough space to conveniently
+ *   display those, a small button in the shape of an ⓘ will be displayed instead. Tapping on it
+ *   opens the attribution information in a dialog.
+ * @param attributionAlignment where to place the attribution information
+ * @param isCompassEnabled whether to display a compass that shows which direction is north. Tapping
+ *   on the compass will reset the camera rotations to zero.
+ * @param compassAlignment where to place the compass
+ */
 @Stable
 public data class OrnamentSettings(
   val padding: PaddingValues = PaddingValues(0.dp),

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/OrnamentSettings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/OrnamentSettings.kt
@@ -1,9 +1,26 @@
 package dev.sargunv.maplibrecompose.core
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 
+/**
+ *  Defines which additional UI elements are displayed on top of the map.
+ *
+ *  @param padding padding of the ornaments to the edge of the map
+ *  @param isLogoEnabled whether to display the MapLibre logo
+ *  @param logoAlignment where to place the MapLibre logo
+ *  @param isAttributionEnabled whether to display copyright attribution information. If `true`,
+ *    all attribution for all sources used is displayed. If there is not enough space to
+ *    conveniently display those, a small button in the shape of an ⓘ will be displayed instead.
+ *    Tapping on it opens the attribution information in a dialog.
+ *  @param attributionAlignment where to place the attribution information
+ *  @param isCompassEnabled whether to display a compass that shows which direction is north.
+ *    Tapping on the compass will reset the camera rotations to zero.
+ *  @param compassAlignment where to place the compass
+ * */
+@Stable
 public data class OrnamentSettings(
   val padding: PaddingValues = PaddingValues(0.dp),
   val isLogoEnabled: Boolean = true,
@@ -12,4 +29,8 @@ public data class OrnamentSettings(
   val attributionAlignment: Alignment = Alignment.BottomEnd,
   val isCompassEnabled: Boolean = true,
   val compassAlignment: Alignment = Alignment.TopEnd,
-)
+) {
+  public companion object {
+    public val AllEnabled: OrnamentSettings = OrnamentSettings()
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
@@ -16,11 +16,12 @@ import dev.sargunv.maplibrecompose.core.expression.Expression
  * @param cluster If the data is a collection of point features, setting this to `true` clusters the
  *   points by radius into groups. Cluster groups become new `Point` features in the source with
  *   additional properties:
- *   * `cluster`: Is `true` if the point is a cluster
- *   * `cluster_id`: A unique id for the cluster to be used in conjunction with the cluster
+ *     * `cluster`: Is `true` if the point is a cluster
+ *     * `cluster_id`: A unique id for the cluster to be used in conjunction with the cluster
  *       inspection methods. (TODO which are not implemented yet on [GeoJsonSource])
- *   * `point_count`: Number of original points grouped into this cluster
- *   * `point_count_abbreviated`: An abbreviated point count
+ *     * `point_count`: Number of original points grouped into this cluster
+ *     * `point_count_abbreviated`: An abbreviated point count
+ *
  * @param clusterRadius Radius of each cluster when clustering points, measured in 1/512ths of a
  *   tile. I.e. a value of 512 indicates a radius equal to the width of a tile.
  * @param clusterMaxZoom Max zoom to cluster points on. Clusters are re-evaluated at integer zoom
@@ -31,9 +32,10 @@ import dev.sargunv.maplibrecompose.core.expression.Expression
  *   values are expressions.
  *
  *   TODO examples missing, see https://maplibre.org/maplibre-style-spec/sources/#clusterproperties
+ *
  * @param lineMetrics Whether to calculate line distance metrics. This is required for line layers
  *   that specify line-gradient values.
- * */
+ */
 // not supported yet:
 // @param clusterMinPoints Minimum number of points necessary to form a cluster if clustering is
 //   enabled.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
@@ -5,6 +5,7 @@ import dev.sargunv.maplibrecompose.core.expression.Expression
 
 @Immutable
 public data class GeoJsonOptions(
+  val minZoom: Int = 0,
   val maxZoom: Int = 18,
   val buffer: Int = 128,
   val tolerance: Float = 0.375f,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
@@ -3,6 +3,40 @@ package dev.sargunv.maplibrecompose.core.source
 import androidx.compose.runtime.Immutable
 import dev.sargunv.maplibrecompose.core.expression.Expression
 
+/**
+ * @param minZoom Minimum zoom level at which to create vector tiles (lower means more field of view
+ *   detail at low zoom levels).
+ * @param maxZoom Maximum zoom level at which to create vector tiles (higher means greater detail at
+ *   high zoom levels).
+ * @param buffer Size of the tile buffer on each side. A value of 0 produces no buffer. A value of
+ *   512 produces a buffer as wide as the tile itself. Larger values produce fewer rendering
+ *   artifacts near tile edges at the cost of slower performance.
+ * @param tolerance Douglas-Peucker simplification tolerance (higher means simpler geometries and
+ *   faster performance).
+ * @param cluster If the data is a collection of point features, setting this to `true` clusters the
+ *   points by radius into groups. Cluster groups become new `Point` features in the source with
+ *   additional properties:
+ *   * `cluster`: Is `true` if the point is a cluster
+ *   * `cluster_id`: A unique id for the cluster to be used in conjunction with the cluster
+ *       inspection methods. (TODO which are not implemented yet on [GeoJsonSource])
+ *   * `point_count`: Number of original points grouped into this cluster
+ *   * `point_count_abbreviated`: An abbreviated point count
+ * @param clusterRadius Radius of each cluster when clustering points, measured in 1/512ths of a
+ *   tile. I.e. a value of 512 indicates a radius equal to the width of a tile.
+ * @param clusterMaxZoom Max zoom to cluster points on. Clusters are re-evaluated at integer zoom
+ *   levels. So, setting the max zoom to 14 means that the clusters will still be displayed on zoom
+ *   14.9.
+ * @param clusterProperties A map defining custom properties on the generated clusters if clustering
+ *   is enabled, aggregating values from clustered points. The keys are the property names, the
+ *   values are expressions.
+ *
+ *   TODO examples missing, see https://maplibre.org/maplibre-style-spec/sources/#clusterproperties
+ * @param lineMetrics Whether to calculate line distance metrics. This is required for line layers
+ *   that specify line-gradient values.
+ * */
+// not supported yet:
+// @param clusterMinPoints Minimum number of points necessary to form a cluster if clustering is
+//   enabled.
 @Immutable
 public data class GeoJsonOptions(
   val minZoom: Int = 0,
@@ -11,9 +45,12 @@ public data class GeoJsonOptions(
   val tolerance: Float = 0.375f,
   val cluster: Boolean = false,
   val clusterRadius: Int = 50,
+  // Not supported yet on Android, iOS: https://github.com/maplibre/maplibre-native/issues/261
+  // val clusterMinPoints: Int = 2,
   val clusterMaxZoom: Int = maxZoom - 1,
   val clusterProperties: Map<String, ClusterProperty> = emptyMap(),
   val lineMetrics: Boolean = false,
 ) {
+  // TODO seems to contradict https://maplibre.org/maplibre-style-spec/sources/#clusterproperties
   public data class ClusterProperty(val operator: String, val mapper: Expression<*>)
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -36,6 +36,7 @@ public actual class GeoJsonSource : Source {
 
   private fun buildOptionMap(options: GeoJsonOptions) =
     buildMap<Any?, Any?> {
+      put(MLNShapeSourceOptionMinimumZoomLevel , NSNumber(options.minZoom))
       put(MLNShapeSourceOptionMaximumZoomLevel, NSNumber(options.maxZoom))
       put(MLNShapeSourceOptionBuffer, NSNumber(options.buffer))
       put(MLNShapeSourceOptionLineDistanceMetrics, NSNumber(options.lineMetrics))

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -8,6 +8,7 @@ import cocoapods.MapLibre.MLNShapeSourceOptionClustered
 import cocoapods.MapLibre.MLNShapeSourceOptionLineDistanceMetrics
 import cocoapods.MapLibre.MLNShapeSourceOptionMaximumZoomLevel
 import cocoapods.MapLibre.MLNShapeSourceOptionMaximumZoomLevelForClustering
+import cocoapods.MapLibre.MLNShapeSourceOptionMinimumZoomLevel
 import cocoapods.MapLibre.MLNShapeSourceOptionSimplificationTolerance
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -36,7 +36,7 @@ public actual class GeoJsonSource : Source {
 
   private fun buildOptionMap(options: GeoJsonOptions) =
     buildMap<Any?, Any?> {
-      put(MLNShapeSourceOptionMinimumZoomLevel , NSNumber(options.minZoom))
+      put(MLNShapeSourceOptionMinimumZoomLevel, NSNumber(options.minZoom))
       put(MLNShapeSourceOptionMaximumZoomLevel, NSNumber(options.maxZoom))
       put(MLNShapeSourceOptionBuffer, NSNumber(options.buffer))
       put(MLNShapeSourceOptionLineDistanceMetrics, NSNumber(options.lineMetrics))


### PR DESCRIPTION
also, I noticed that on iOS, there doesn't seem to be an option to turn on/off the
- double tap to zoom in
- double tap, then hold and drag up or down to zoom
gestures separately from zooming via gesture at all.

So, to achieve the same behavior on all platforms, on Android, we need to set all these separate settings to true/false when the allow-zoom setting changes.