### PR TITLE
combine dokka and mkdocs output into single docs site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: "./.github/actions/setup"
-      - run: "./gradlew :dokkaGenerate"
+      - run: "./gradlew generateDocs"
       - uses: "actions/upload-pages-artifact@v3"
         with:
-          path: "build/dokka/html"
+          path: "build/docs"
 
   build-android-app:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: "./.github/actions/setup"
-      - run: "./gradlew :dokkaGenerate"
+      - run: "./gradlew generateDocs"
       - uses: "actions/upload-pages-artifact@v3"
         with:
-          path: "build/dokka/html"
+          path: "build/docs"
       - uses: "actions/deploy-pages@v4"
         id: "deploy-pages"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,29 @@ plugins {
   alias(libs.plugins.mkdocs)
 }
 
-mkdocs { sourcesDir = "docs" }
+mkdocs {
+  sourcesDir = "docs"
+  strict = true
+  publish {
+    docPath = null // single version site
+  }
+}
 
 dokka { moduleName = "MapLibre Compose API Reference" }
+
+tasks.register("generateDocs") {
+  dependsOn("dokkaGenerate", "mkdocsBuild")
+  doLast {
+    copy {
+      from(layout.buildDirectory.dir("mkdocs"))
+      into(layout.buildDirectory.dir("docs"))
+    }
+    copy {
+      from(layout.buildDirectory.dir("dokka/html"))
+      into(layout.buildDirectory.dir("docs/api"))
+    }
+  }
+}
 
 dependencies { dokka(project(":lib:maplibre-compose:")) }
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,3 +1,4 @@
 # MapLibre Compose
 
-TODO
+* [API Reference](./api/)
+


### PR DESCRIPTION
Updates documentation generation to combine API reference and user guide into a single documentation site. The API reference is now accessible through a link on the main documentation page, and both the API reference and user guide are built into a unified directory structure.

The changes standardize the documentation output path to `build/docs` and introduce a new `generateDocs` Gradle task that coordinates the generation of both documentation types.

See #17 
