### PR TITLE
docs: reorganize readme and add documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Maven Central Version](https://img.shields.io/maven-central/v/dev.sargunv.maplibre-compose/maplibre-compose)](https://central.sonatype.com/namespace/dev.sargunv.maplibre-compose)
-[![Github Actions](https://github.com/sargunv/maplibre-compose/actions/workflows/ci.yml/badge.svg)](https://github.com/sargunv/maplibre-compose/actions/workflows/ci.yml?query=branch%3Amain)
 [![License](https://img.shields.io/github/license/sargunv/maplibre-compose)](https://github.com/sargunv/maplibre-compose/blob/main/LICENSE)
+[![Documentation](https://img.shields.io/badge/Documentation-blue?logo=MaterialForMkDocs&logoColor=white)](https://sargunv.github.io/maplibre-compose/)
+[![API Reference](https://img.shields.io/badge/API_Reference-blue?logo=Kotlin&logoColor=white)](https://sargunv.github.io/material-compose/api/)
 
 # MapLibre for Compose
 
@@ -9,11 +10,6 @@ This project is a
 library for [MapLibre](https://maplibre.org/). You can use it to embed an
 interactive vector map in your Compose app.
 
-Android and iOS support is implemented with
-[MapLibre Native](https://github.com/maplibre/maplibre-native).
-
-Desktop and Web are not yet supported.
-
 <p float="left">
   <img src="https://github.com/user-attachments/assets/671fc56d-b1a8-4843-82ea-4813c9712ea3" width="200"/>
   <img src="https://github.com/user-attachments/assets/ae4a43e4-66bc-4a69-824f-957874912abd" width="200"/>
@@ -21,50 +17,9 @@ Desktop and Web are not yet supported.
 
 ## Usage
 
-This library is published via
-[Maven Central](https://central.sonatype.com/namespace/dev.sargunv.maplibre-compose),
-and snapshot builds of `main` are additionally available on
-[GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry).
-
-In your Gradle version catalog, add:
-
-```toml
-[libraries]
-# ...
-maplibre-compose = { module = "dev.sargunv.maplibre-compose:maplibre-compose", version = "0.1.0" }
-```
-
-In your Gradle build script, add:
-
-```kotlin
-commonMain.dependencies {
-  // ...
-  implementation(libs.maplibre.compose)
-}
-```
-
-For iOS, you'll additionally need to add the MapLibre framework to your build.
-The easiest way to do this in Kotlin Multiplatform is with the
-[CocoaPods Gradle plugin](https://kotlinlang.org/docs/native-cocoapods.html):
-
-```kotlin
-cocoapods {
-  // ...
-  pod("MapLibre", "6.8.1")
-}
-```
-
-In your app's UI, add a map:
-
-```kotlin
-@Composable
-fun MyMapScreen() {
-  MaplibreMap()
-}
-```
-
-For full usage information, see the [demo app](./demo-app) and
-[docs](https://sargunv.github.io/maplibre-compose/).
+See the
+[Getting Started guide](https://sargunv.github.io/maplibre-compose/getting-started/)
+in the documentation.
 
 ## Status
 
@@ -73,58 +28,7 @@ MapLibre SDKs is not yet covered. What is already supported may have bugs. API
 stability is not yet guaranteed; as we're still exploring how best to express an
 interactive map API in Compose.
 
-The following is currently supported:
+Android and iOS support is implemented with
+[MapLibre Native](https://github.com/maplibre/maplibre-native).
 
-- Instantiate an interactive map in Compose UI
-- Load a [map style](https://maplibre.org/maplibre-style-spec/) via URL,
-  including
-  - Remote (online) styles
-  - Local asset styles with
-    [Compose resources](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-resources.html#access-the-available-resources-in-your-code)
-- Configure the map UI, including:
-  - Position ornaments (compass, logo, attribution) with Compose `PaddingValues`
-    and alignment
-  - Toggle map gestures
-- Position or animate the camera and read its state
-- Dynamically reload the style (say, to switch themes)
-- Add custom layers to the map with a declarative Composable API, including:
-  - Injecting layers in between base style layers (say, to render underneath
-    labels)
-  - Defining GeoJSON sources via URL or
-    [Spatial K](https://dellisd.github.io/spatial-k/geojson/) geometry
-  - Defining raster and vector sources via URL
-  - Defining background, circle, fill, extrusion, heatmap, hillshade, line,
-    raster, and symbol
-    [layers](https://maplibre.org/maplibre-style-spec/layers/)
-  - Configuring layers with
-    [expressions](https://maplibre.org/maplibre-style-spec/expressions/)
-  - `onClick` and `onLongClick` callbacks with data on which map feature was
-    tapped
-- Replace base style layers, with all the same functionality above
-
-The following is not yet supported, but planned:
-
-- Add annotations
-- Show user location
-- Bound the camera
-- Show a scale bar
-- Configure transitions for transitionable properties
-- Convert between screen space and world space coordinates
-- Query the map for visible features
-- Dynamically configure style properties beyond just sources/layers
-- Configure the offline cache
-- Interact with base style layers
-- Snapshot maps
-
-The following may be explored in the future:
-
-- Support desktop and/or web
-- Support for secondary platforms (car?, watch?, tv?)
-- Expose map style as mutable state for advanced use cases
-- Improve type safety for expressions
-- Depend on the MapLibre Native core directly instead of the Android/IOS SDKs
-- Re-implement camera gestures in Compose and fully hoist camera state
-- Decouple composable style management from map rendering, for use in style
-  generation scripts
-
-Contributions are welcome for any of the above!
+Desktop and Web are not yet supported.


### PR DESCRIPTION
- Add badges for Documentation and API Reference
- Move detailed usage instructions to the documentation site
- Link to the Getting Started guide for setup instructions

