### PR TITLE
use URIs for parameter names instead of URL

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
@@ -39,8 +39,7 @@ object AnimatedLayerDemo : Demo {
         styleUri = DEFAULT_STYLE,
         cameraState = rememberCameraState(firstPosition = CameraPosition(target = US, zoom = 2.0)),
       ) {
-        val routeSource =
-          rememberGeoJsonSource(id = "amtrak-routes", uri = Res.getUri(ROUTES_FILE))
+        val routeSource = rememberGeoJsonSource(id = "amtrak-routes", uri = Res.getUri(ROUTES_FILE))
 
         val infiniteTransition = rememberInfiniteTransition()
         val animatedColor by

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
@@ -36,11 +36,11 @@ object AnimatedLayerDemo : Demo {
   override fun Component(navigateUp: () -> Unit) {
     DemoScaffold(this, navigateUp) {
       MaplibreMap(
-        styleUrl = DEFAULT_STYLE,
+        styleUri = DEFAULT_STYLE,
         cameraState = rememberCameraState(firstPosition = CameraPosition(target = US, zoom = 2.0)),
       ) {
         val routeSource =
-          rememberGeoJsonSource(id = "amtrak-routes", dataUrl = Res.getUri(ROUTES_FILE))
+          rememberGeoJsonSource(id = "amtrak-routes", uri = Res.getUri(ROUTES_FILE))
 
         val infiniteTransition = rememberInfiniteTransition()
         val animatedColor by

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
@@ -74,7 +74,7 @@ object CameraFollowDemo : Demo {
 
         MaplibreMap(
           modifier = Modifier.weight(1f),
-          styleUrl = DEFAULT_STYLE,
+          styleUri = DEFAULT_STYLE,
           cameraState = camera,
         ) {
           LocationPuck(locationSource = rememberGeoJsonSource("target", Point(animatedPosition)))

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraStateDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraStateDemo.kt
@@ -38,7 +38,7 @@ object CameraStateDemo : Demo {
 
         MaplibreMap(
           modifier = Modifier.weight(1f),
-          styleUrl = DEFAULT_STYLE,
+          styleUri = DEFAULT_STYLE,
           cameraState = cameraState,
           onMapClick = { _, _ ->
             println(cameraState.queryVisibleBoundingBox())

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -56,7 +56,7 @@ object ClusteredPointsDemo : Demo {
 
       val coroutineScope = rememberCoroutineScope()
 
-      MaplibreMap(modifier = Modifier, styleUrl = DEFAULT_STYLE, cameraState = cameraState) {
+      MaplibreMap(modifier = Modifier, styleUri = DEFAULT_STYLE, cameraState = cameraState) {
         val gbfsData by rememberGbfsFeatureState(GBFS_FILE)
 
         val bikeSource =

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/EdgeToEdgeDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/EdgeToEdgeDemo.kt
@@ -27,7 +27,7 @@ object EdgeToEdgeDemo : Demo {
       content = { padding ->
         MaplibreMap(
           modifier = Modifier.consumeWindowInsets(padding),
-          styleUrl = DEFAULT_STYLE,
+          styleUri = DEFAULT_STYLE,
           cameraState = rememberCameraState(CameraPosition(target = PORTLAND, zoom = 13.0)),
           ornamentSettings = OrnamentSettings(padding = padding),
         )

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/FrameRateDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/FrameRateDemo.kt
@@ -34,7 +34,7 @@ object FrameRateDemo : Demo {
 
         MaplibreMap(
           modifier = Modifier.weight(1f),
-          styleUrl = DEFAULT_STYLE,
+          styleUri = DEFAULT_STYLE,
           maximumFps = maximumFps,
           onFpsChanged = fpsState::recordFps,
         )

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/StyleSwitcherDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/StyleSwitcherDemo.kt
@@ -37,7 +37,7 @@ object StyleSwitcherDemo : Demo {
 
         MaplibreMap(
           modifier = Modifier.weight(1f),
-          styleUrl = styles[selectedIndex].second,
+          styleUri = styles[selectedIndex].second,
           cameraState = cameraState,
         )
 

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Layers.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Layers.kt
@@ -21,7 +21,7 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 @OptIn(ExperimentalResourceApi::class)
 fun Layers() {
   // -8<- [start:simple]
-  MaplibreMap(styleUrl = "https://tiles.openfreemap.org/styles/liberty") {
+  MaplibreMap(styleUri = "https://tiles.openfreemap.org/styles/liberty") {
     val tiles = getBaseSource(id = "openmaptiles")
     CircleLayer(id = "example", source = tiles, sourceLayer = "poi")
   }
@@ -31,14 +31,14 @@ fun Layers() {
     val amtrakStations =
       rememberGeoJsonSource(
         id = "amtrak-stations",
-        dataUrl = Res.getUri("files/data/amtrak_stations.geojson"),
+        uri = Res.getUri("files/data/amtrak_stations.geojson"),
       )
 
     // -8<- [start:amtrak-1]
     val amtrakRoutes =
       rememberGeoJsonSource(
         id = "amtrak-routes",
-        dataUrl = Res.getUri("files/data/amtrak_routes.geojson"),
+        uri = Res.getUri("files/data/amtrak_routes.geojson"),
       )
     LineLayer(
       id = "amtrak-routes-casing",

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Styling.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Styling.kt
@@ -12,15 +12,15 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 @OptIn(ExperimentalResourceApi::class)
 fun Styling() {
   // -8<- [start:simple]
-  MaplibreMap(styleUrl = "https://tiles.openfreemap.org/styles/liberty")
+  MaplibreMap(styleUri = "https://tiles.openfreemap.org/styles/liberty")
   // -8<- [end:simple]
 
   // -8<- [start:dynamic]
   val variant = if (isSystemInDarkTheme()) "dark" else "light"
-  MaplibreMap(styleUrl = "https://api.protomaps.com/styles/v4/$variant/en.json?key=MY_KEY")
+  MaplibreMap(styleUri = "https://api.protomaps.com/styles/v4/$variant/en.json?key=MY_KEY")
   // -8<- [end:dynamic]
 
   // -8<- [start:local]
-  MaplibreMap(styleUrl = Res.getUri("files/style.json"))
+  MaplibreMap(styleUri = Res.getUri("files/style.json"))
   // -8<- [end:local]
 }

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/util.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/util.kt
@@ -20,7 +20,7 @@ interface Demo {
   @Composable fun Component(navigateUp: () -> Unit)
 }
 
-private val REMOTE_STYLE_URLS =
+private val REMOTE_STYLE_URIS =
   listOf(
     "Bright" to "https://tiles.openfreemap.org/styles/bright",
     "Liberty" to "https://tiles.openfreemap.org/styles/liberty",
@@ -32,11 +32,11 @@ private val REMOTE_STYLE_URLS =
 // TODO demo some local styles
 private val LOCAL_STYLE_PATHS = emptyList<Pair<String, String>>()
 
-val DEFAULT_STYLE = REMOTE_STYLE_URLS[0].second
+val DEFAULT_STYLE = REMOTE_STYLE_URIS[0].second
 
 @OptIn(ExperimentalResourceApi::class)
 fun getAllStyleUrls() =
-  REMOTE_STYLE_URLS + LOCAL_STYLE_PATHS.map { it.first to Res.getUri(it.second) }
+  REMOTE_STYLE_URIS + LOCAL_STYLE_PATHS.map { it.first to Res.getUri(it.second) }
 
 /** Caution: this converter results in a loss of precision far from the origin. */
 class PositionVectorConverter(private val origin: Position) :

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -33,7 +33,7 @@ Android and iOS support is implemented with [MapLibre Native][maplibre-native].
 | Get the currently visible region and bounding box | :white_check_mark: | :white_check_mark: | :x:     | :x: |
 | Insert, remove, and replace layers                | :white_check_mark: | :white_check_mark: | :x:     | :x: |
 | Configure layers with expressions                 | :white_check_mark: | :white_check_mark: | :x:     | :x: |
-| Add data sources by URL or GeoJSON                | :white_check_mark: | :white_check_mark: | :x:     | :x: |
+| Add data sources by URI or GeoJSON                | :white_check_mark: | :white_check_mark: | :x:     | :x: |
 | Snapshot the map as an image                      | :x:                | :x:                | :x:     | :x: |
 | Configure the offline cache                       | :x:                | :x:                | :x:     | :x: |
 | Configure layer transitions                       | :x:                | :x:                | :x:     | :x: |

--- a/docs/docs/layers.md
+++ b/docs/docs/layers.md
@@ -3,7 +3,7 @@
 ## Sources and layers
 
 As covered in [Styling the map](styling.md), the data displayed on the map is
-defined by the style, which is provided as a URL to a JSON object. However, this
+defined by the style, which is provided as a URI to a JSON object. However, this
 library provides a way to add additional data to the map at runtime.
 
 A map style primarily consists of sources and layers. Sources contain the data

--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -5,7 +5,7 @@
 Every MapLibre map requires a style to be displayed. The style is a JSON object
 that describes what data to display and how to display it. Typically, vector
 tile providers create styles designed to work with their data, and provide them
-as a URL. You can also create your own styles using [Maputnik][maputnik], a
+as a URI. You can also create your own styles using [Maputnik][maputnik], a
 visual style editor for MapLibre styles.
 
 There are a variety of free and commercial map tile providers available. See the
@@ -16,7 +16,7 @@ styles.
 
 ## Using a style
 
-To use a style, you can pass the `styleUrl` of your chosen style to the
+To use a style, you can pass the `styleUri` of your chosen style to the
 `MaplibreMap` composable:
 
 ```kotlin

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
@@ -19,7 +19,7 @@ import org.maplibre.android.maps.MapView
 @Composable
 internal actual fun ComposableMapView(
   modifier: Modifier,
-  styleUrl: String,
+  styleUri: String,
   update: (map: MaplibreMap) -> Unit,
   onReset: () -> Unit,
   logger: Logger?,
@@ -27,7 +27,7 @@ internal actual fun ComposableMapView(
 ) {
   AndroidMapView(
     modifier = modifier,
-    styleUrl = styleUrl,
+    styleUri = styleUri,
     update = update,
     onReset = onReset,
     logger = logger,
@@ -38,7 +38,7 @@ internal actual fun ComposableMapView(
 @Composable
 internal fun AndroidMapView(
   modifier: Modifier,
-  styleUrl: String,
+  styleUri: String,
   update: (map: MaplibreMap) -> Unit,
   onReset: () -> Unit,
   logger: Logger?,
@@ -67,7 +67,7 @@ internal fun AndroidMapView(
               layoutDir = layoutDir,
               density = density,
               callbacks = callbacks,
-              styleUrl = styleUrl,
+              styleUri = styleUri,
               logger = logger,
             )
         }
@@ -78,7 +78,7 @@ internal fun AndroidMapView(
       map.layoutDir = layoutDir
       map.density = density
       map.callbacks = callbacks
-      map.styleUrl = styleUrl
+      map.styleUri = styleUri
       map.logger = logger
       update(map)
     },

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -52,7 +52,7 @@ internal class AndroidMap(
   internal var density: Density,
   internal var callbacks: MaplibreMap.Callbacks,
   logger: Logger?,
-  styleUrl: String,
+  styleUri: String,
 ) : MaplibreMap {
 
   internal var logger: Logger? = logger
@@ -63,10 +63,10 @@ internal class AndroidMap(
       }
     }
 
-  override var styleUrl: String = ""
+  override var styleUri: String = ""
     set(value) {
       if (field == value) return
-      logger?.i { "Setting style URL" }
+      logger?.i { "Setting style URI" }
       callbacks.onStyleChanged(this, null)
       val builder = MlnStyle.Builder().fromUri(value.correctedAndroidUri().toString())
       map.setStyle(builder) {
@@ -161,7 +161,7 @@ internal class AndroidMap(
 
     map.setOnFpsChangedListener { onFpsChanged(it) }
 
-    this.styleUrl = styleUrl
+    this.styleUri = styleUri
   }
 
   override var isDebugEnabled

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -10,8 +10,8 @@ import org.maplibre.android.style.sources.GeoJsonSource as MLNGeoJsonSource
 public actual class GeoJsonSource : Source {
   override val impl: MLNGeoJsonSource
 
-  public actual constructor(id: String, dataUrl: String, options: GeoJsonOptions) {
-    impl = MLNGeoJsonSource(id, dataUrl.correctedAndroidUri(), buildOptionMap(options))
+  public actual constructor(id: String, uri: String, options: GeoJsonOptions) {
+    impl = MLNGeoJsonSource(id, uri.correctedAndroidUri(), buildOptionMap(options))
   }
 
   public actual constructor(id: String, data: GeoJson, options: GeoJsonOptions) {
@@ -37,8 +37,8 @@ public actual class GeoJsonSource : Source {
       }
     }
 
-  public actual fun setDataUrl(url: String) {
-    impl.setUri(url.correctedAndroidUri())
+  public actual fun setUri(uri: String) {
+    impl.setUri(uri.correctedAndroidUri())
   }
 
   public actual fun setData(geoJson: GeoJson) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
@@ -3,6 +3,6 @@ package dev.sargunv.maplibrecompose.core.source
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
 import org.maplibre.android.style.sources.RasterSource
 
-public actual class RasterSource actual constructor(id: String, configUrl: String) : Source() {
-  override val impl: RasterSource = RasterSource(id, configUrl.correctedAndroidUri().toString())
+public actual class RasterSource actual constructor(id: String, uri: String) : Source() {
+  override val impl: RasterSource = RasterSource(id, uri.correctedAndroidUri().toString())
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -3,6 +3,6 @@ package dev.sargunv.maplibrecompose.core.source
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
 import org.maplibre.android.style.sources.VectorSource
 
-public actual class VectorSource actual constructor(id: String, configUrl: String) : Source() {
-  override val impl: VectorSource = VectorSource(id, configUrl.correctedAndroidUri().toString())
+public actual class VectorSource actual constructor(id: String, uri: String) : Source() {
+  override val impl: VectorSource = VectorSource(id, uri.correctedAndroidUri().toString())
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/ComposableMapView.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/ComposableMapView.kt
@@ -8,7 +8,7 @@ import dev.sargunv.maplibrecompose.core.MaplibreMap
 @Composable
 internal expect fun ComposableMapView(
   modifier: Modifier,
-  styleUrl: String,
+  styleUri: String,
   update: (map: MaplibreMap) -> Unit,
   onReset: () -> Unit,
   logger: Logger?,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -23,7 +23,7 @@ import kotlin.math.roundToInt
 @Composable
 public fun MaplibreMap(
   modifier: Modifier = Modifier,
-  styleUrl: String = "https://demotiles.maplibre.org/style.json",
+  styleUri: String = "https://demotiles.maplibre.org/style.json",
   gestureSettings: GestureSettings = GestureSettings.AllEnabled,
   ornamentSettings: OrnamentSettings = OrnamentSettings.AllEnabled,
   cameraState: CameraState = rememberCameraState(),
@@ -95,7 +95,7 @@ public fun MaplibreMap(
 
   ComposableMapView(
     modifier = modifier,
-    styleUrl = styleUrl,
+    styleUri = styleUri,
     update = { map ->
       cameraState.map = map
       map.onFpsChanged = onFpsChanged

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberGeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberGeoJsonSource.kt
@@ -11,13 +11,13 @@ import io.github.dellisd.spatialk.geojson.GeoJson
 @Suppress("NOTHING_TO_INLINE")
 public inline fun rememberGeoJsonSource(
   id: String,
-  dataUrl: String,
+  uri: String,
   options: GeoJsonOptions = GeoJsonOptions(),
 ): Source =
   key(id, options) {
     rememberUserSource(
-      factory = { GeoJsonSource(id = id, dataUrl = dataUrl, options = options) },
-      update = { setDataUrl(dataUrl) },
+      factory = { GeoJsonSource(id = id, uri = uri, options = options) },
+      update = { setUri(uri) },
     )
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberRasterSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberRasterSource.kt
@@ -7,7 +7,7 @@ import dev.sargunv.maplibrecompose.core.source.Source
 
 @Composable
 @Suppress("NOTHING_TO_INLINE")
-public inline fun rememberRasterSource(id: String, configUrl: String): Source =
-  composeKey(id, configUrl) {
-    rememberUserSource(factory = { RasterSource(id = id, configUrl = configUrl) }, update = {})
+public inline fun rememberRasterSource(id: String, uri: String): Source =
+  composeKey(id, uri) {
+    rememberUserSource(factory = { RasterSource(id = id, uri = uri) }, update = {})
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberVectorSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberVectorSource.kt
@@ -1,13 +1,13 @@
 package dev.sargunv.maplibrecompose.compose.source
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
 import dev.sargunv.maplibrecompose.core.source.Source
+import androidx.compose.runtime.key as composeKey
 import dev.sargunv.maplibrecompose.core.source.VectorSource
 
 @Composable
 @Suppress("NOTHING_TO_INLINE")
-public inline fun rememberVectorSource(id: String, configUrl: String): Source =
-  composeKey(id, configUrl) {
-    rememberUserSource(factory = { VectorSource(id = id, configUrl = configUrl) }, update = {})
+public inline fun rememberVectorSource(id: String, uri: String): Source =
+  composeKey(id, uri) {
+    rememberUserSource(factory = { VectorSource(id = id, uri = uri) }, update = {})
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberVectorSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberVectorSource.kt
@@ -1,8 +1,8 @@
 package dev.sargunv.maplibrecompose.compose.source
 
 import androidx.compose.runtime.Composable
-import dev.sargunv.maplibrecompose.core.source.Source
 import androidx.compose.runtime.key as composeKey
+import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.source.VectorSource
 
 @Composable

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
@@ -9,7 +9,7 @@ import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration
 
 internal interface MaplibreMap {
-  var styleUrl: String
+  var styleUri: String
   var isDebugEnabled: Boolean
   var cameraPosition: CameraPosition
   var onFpsChanged: (Double) -> Unit

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -3,11 +3,11 @@ package dev.sargunv.maplibrecompose.core.source
 import io.github.dellisd.spatialk.geojson.GeoJson
 
 public expect class GeoJsonSource : Source {
-  public constructor(id: String, dataUrl: String, options: GeoJsonOptions)
+  public constructor(id: String, uri: String, options: GeoJsonOptions)
 
   public constructor(id: String, data: GeoJson, options: GeoJsonOptions)
 
-  public fun setDataUrl(url: String)
+  public fun setUri(uri: String)
 
   public fun setData(geoJson: GeoJson)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
@@ -1,3 +1,3 @@
 package dev.sargunv.maplibrecompose.core.source
 
-public expect class RasterSource(id: String, configUrl: String) : Source
+public expect class RasterSource(id: String, uri: String) : Source

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,3 +1,3 @@
 package dev.sargunv.maplibrecompose.core.source
 
-public expect class VectorSource(id: String, configUrl: String) : Source
+public expect class VectorSource(id: String, uri: String) : Source

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/compose/IosMapView.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/compose/IosMapView.kt
@@ -28,7 +28,7 @@ import platform.Foundation.NSURL
 @Composable
 internal actual fun ComposableMapView(
   modifier: Modifier,
-  styleUrl: String,
+  styleUri: String,
   update: (map: MaplibreMap) -> Unit,
   onReset: () -> Unit,
   logger: Logger?,
@@ -36,7 +36,7 @@ internal actual fun ComposableMapView(
 ) {
   IosMapView(
     modifier = modifier,
-    styleUrl = styleUrl,
+    styleUri = styleUri,
     update = update,
     onReset = onReset,
     logger = logger,
@@ -48,7 +48,7 @@ internal actual fun ComposableMapView(
 @Composable
 internal fun IosMapView(
   modifier: Modifier,
-  styleUrl: String,
+  styleUri: String,
   update: (map: MaplibreMap) -> Unit,
   onReset: () -> Unit,
   logger: Logger?,
@@ -75,7 +75,7 @@ internal fun IosMapView(
                 width = width.value.toDouble(),
                 height = height.value.toDouble(),
               ),
-            styleURL = NSURL(string = styleUrl),
+            styleURL = NSURL(string = styleUri),
           )
           .also { mapView ->
             currentMap =
@@ -97,7 +97,7 @@ internal fun IosMapView(
         map.density = density
         map.insetPadding = insetPadding
         map.callbacks = callbacks
-        map.styleUrl = styleUrl
+        map.styleUri = styleUri
         map.logger = logger
         update(map)
       },

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -95,10 +95,10 @@ internal class IosMap(
   private val gestures = mutableListOf<Gesture<*>>()
   private val delegate: Delegate
 
-  override var styleUrl: String = ""
+  override var styleUri: String = ""
     set(value) {
       if (field == value) return
-      logger?.i { "Setting style URL" }
+      logger?.i { "Setting style URI" }
       callbacks.onStyleChanged(this, null)
       mapView.setStyleURL(NSURL(string = value))
       field = value

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -23,11 +23,7 @@ public actual class GeoJsonSource : Source {
 
   public actual constructor(id: String, uri: String, options: GeoJsonOptions) {
     impl =
-      MLNShapeSource(
-        identifier = id,
-        URL = NSURL(string = uri),
-        options = buildOptionMap(options),
-      )
+      MLNShapeSource(identifier = id, URL = NSURL(string = uri), options = buildOptionMap(options))
   }
 
   public actual constructor(id: String, data: GeoJson, options: GeoJsonOptions) {

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -21,11 +21,11 @@ import platform.Foundation.NSURL
 public actual class GeoJsonSource : Source {
   override val impl: MLNShapeSource
 
-  public actual constructor(id: String, dataUrl: String, options: GeoJsonOptions) {
+  public actual constructor(id: String, uri: String, options: GeoJsonOptions) {
     impl =
       MLNShapeSource(
         identifier = id,
-        URL = NSURL(string = dataUrl),
+        URL = NSURL(string = uri),
         options = buildOptionMap(options),
       )
   }
@@ -53,8 +53,8 @@ public actual class GeoJsonSource : Source {
       )
     }
 
-  public actual fun setDataUrl(url: String) {
-    impl.setURL(NSURL(string = url))
+  public actual fun setUri(uri: String) {
+    impl.setURL(NSURL(string = uri))
   }
 
   public actual fun setData(geoJson: GeoJson) {

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
@@ -3,6 +3,6 @@ package dev.sargunv.maplibrecompose.core.source
 import cocoapods.MapLibre.MLNRasterTileSource
 import platform.Foundation.NSURL
 
-public actual class RasterSource actual constructor(id: String, configUrl: String) : Source() {
-  override val impl: MLNRasterTileSource = MLNRasterTileSource(id, NSURL(string = configUrl))
+public actual class RasterSource actual constructor(id: String, uri: String) : Source() {
+  override val impl: MLNRasterTileSource = MLNRasterTileSource(id, NSURL(string = uri))
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -3,6 +3,6 @@ package dev.sargunv.maplibrecompose.core.source
 import cocoapods.MapLibre.MLNVectorTileSource
 import platform.Foundation.NSURL
 
-public actual class VectorSource actual constructor(id: String, configUrl: String) : Source() {
-  override val impl: MLNVectorTileSource = MLNVectorTileSource(id, NSURL(string = configUrl))
+public actual class VectorSource actual constructor(id: String, uri: String) : Source() {
+  override val impl: MLNVectorTileSource = MLNVectorTileSource(id, NSURL(string = uri))
 }


### PR DESCRIPTION
...because styles and sources can be specified via `Res.getUri(...)`, too. The resources are accessed by identifier, not by locator.

Also, renamed any "dataUrl"/"dataUri" to just "uri" because data uris are already [something different](https://en.wikipedia.org/wiki/Data_URI_scheme) - to avoid confusion.