### PR TITLE
build: upgrade dependencies and organize gradle version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
   // in each subproject's classloader
   alias(libs.plugins.android.application) apply false
   alias(libs.plugins.android.library) apply false
-  alias(libs.plugins.jetbrains.compose) apply false
-  alias(libs.plugins.kotlin.compose) apply false
+  alias(libs.plugins.compose) apply false
+  alias(libs.plugins.kotlin.composeCompiler) apply false
   alias(libs.plugins.kotlin.multiplatform) apply false
   alias(libs.plugins.kotlin.cocoapods) apply false
   alias(libs.plugins.spotless)

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -10,8 +10,8 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.android.application)
-  alias(libs.plugins.kotlin.compose)
-  alias(libs.plugins.jetbrains.compose)
+  alias(libs.plugins.kotlin.composeCompiler)
+  alias(libs.plugins.compose)
   alias(libs.plugins.kotlin.cocoapods)
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.spotless)
@@ -57,7 +57,7 @@ kotlin {
   cocoapods {
     summary = "PLACEHOLDER SUMMARY"
     homepage = "PLACEHOLDER HOMEPAGE"
-    ios.deploymentTarget = "15.3"
+    ios.deploymentTarget = libs.versions.ios.deploymentTarget.get()
     podfile = project.file("../iosApp/Podfile")
     framework {
       baseName = "DemoApp"
@@ -83,10 +83,10 @@ kotlin {
       implementation(compose.material3)
       implementation(compose.runtime)
       implementation(compose.ui)
-      implementation(libs.navigation.compose)
+      implementation(libs.androidx.navigation.compose)
       implementation(libs.ktor.client.core)
-      implementation(libs.ktor.client.content.negotiation)
-      implementation(libs.ktor.serialization.kotlinx.json)
+      implementation(libs.ktor.client.contentNegotiation)
+      implementation(libs.ktor.serialization.kotlinxJson)
       implementation(project(":lib:maplibre-compose"))
     }
 
@@ -109,7 +109,7 @@ kotlin {
 
     androidInstrumentedTest.dependencies {
       implementation(compose.desktop.uiTestJUnit4)
-      implementation(libs.compose.ui.test.manifest)
+      implementation(libs.androidx.composeUi.testManifest)
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,37 +1,50 @@
 [versions]
-agp = "8.5.2"
-android-compileSdk = "34"
+android-compileSdk = "35"
 android-minSdk = "23"
-android-targetSdk = "34"
-compose = "1.7.1"
-compose-androidx = "1.7.5"
-kotlin = "2.1.0"
-ktor = "3.0.1"
+android-targetSdk = "35"
+ios-deploymentTarget = "15.3"
+
+androidx-activity = "1.9.3"
+androidx-composeUi = "1.7.5"
+androidx-navigation = "2.8.0-alpha10"
+kermit = "2.0.5"
+ktor = "3.0.2"
+maplibre-android = "11.6.1"
 maplibre-ios = "6.8.1"
+spatialk = "0.3.0"
+
+gradle-android = "8.7.3"
+gradle-compose = "1.7.1"
+gradle-dokka = "2.0.0-Beta"
+gradle-jgitver = "0.10.0-rc03"
+gradle-kotlin = "2.1.0"
+gradle-mavenPublish = "0.30.0"
+gradle-mkdocs = "4.0.1"
+gradle-spotless = "7.0.0.BETA4"
 
 [libraries]
-androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.9.3" }
-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-androidx" }
-kermit = { group = "co.touchlab", name = "kermit", version = "2.0.5" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-composeUi-testManifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-composeUi" }
+androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
+kermit = { group = "co.touchlab", name = "kermit", version.ref = "kermit" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
-ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
-ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-maplibre-android = { module = "org.maplibre.gl:android-sdk", version = "11.6.1" }
-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version = "2.8.0-alpha10" }
-spatialk-geojson = { group = "io.github.dellisd.spatialk", name = "geojson", version = "0.3.0" }
+ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+maplibre-android = { module = "org.maplibre.gl:android-sdk", version.ref = "maplibre-android" }
+spatialk-geojson = { group = "io.github.dellisd.spatialk", name = "geojson", version.ref = "spatialk" }
 
 [plugins]
-android-application = { id = "com.android.application", version.ref = "agp" }
-android-library = { id = "com.android.library", version.ref = "agp" }
-dokka = { id = "org.jetbrains.dokka", version = "2.0.0-Beta" }
-jetbrains-compose = { id = "org.jetbrains.compose", version.ref = "compose" }
-jgitver = { id = "fr.brouillard.oss.gradle.jgitver", version = "0.10.0-rc03" }
-kotlin-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
-kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.30.0" }
-mkdocs = { id = "ru.vyarus.mkdocs-build", version = "4.0.1" }
-spotless = { id = "com.diffplug.spotless", version = "7.0.0.BETA4" }
+android-application = { id = "com.android.application", version.ref = "gradle-android" }
+android-library = { id = "com.android.library", version.ref = "gradle-android" }
+compose = { id = "org.jetbrains.compose", version.ref = "gradle-compose" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "gradle-dokka" }
+jgitver = { id = "fr.brouillard.oss.gradle.jgitver", version.ref = "gradle-jgitver" }
+kotlin-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "gradle-kotlin" }
+kotlin-composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "gradle-kotlin" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "gradle-kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "gradle-kotlin" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "gradle-mavenPublish" }
+mkdocs = { id = "ru.vyarus.mkdocs-build", version.ref = "gradle-mkdocs" }
+spotless = { id = "com.diffplug.spotless", version.ref = "gradle-spotless" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.kotlin.cocoapods)
   alias(libs.plugins.android.library)
-  alias(libs.plugins.jetbrains.compose)
-  alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.compose)
+  alias(libs.plugins.kotlin.composeCompiler)
   alias(libs.plugins.spotless)
   alias(libs.plugins.dokka)
-  alias(libs.plugins.maven.publish)
+  alias(libs.plugins.mavenPublish)
   alias(libs.plugins.jgitver)
   id("maven-publish")
 }
@@ -97,8 +97,8 @@ kotlin {
     commonMain.dependencies {
       api(compose.runtime)
       api(compose.foundation)
-      api(libs.kermit)
       api(compose.ui)
+      api(libs.kermit)
       api(libs.spatialk.geojson)
     }
 
@@ -116,7 +116,7 @@ kotlin {
 
     androidInstrumentedTest.dependencies {
       implementation(compose.desktop.uiTestJUnit4)
-      implementation(libs.compose.ui.test.manifest)
+      implementation(libs.androidx.composeUi.testManifest)
     }
   }
 }


### PR DESCRIPTION
Updates Gradle dependencies and configuration

- Upgrades Gradle to 8.10
- Upgrades Ktor to 3.0.2
- Updates Android SDK targets to version 35
- Reorganizes version catalog structure with clearer grouping
- Extracts iOS deployment target to version catalog
- Fixes library reference naming to follow consistent pattern
