### PR TITLE
build: fix warnings and enable allWarningsAsErrors

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -2,7 +2,6 @@
 
 import fr.brouillard.oss.jgitver.Strategies
 import org.jetbrains.compose.ExperimentalComposeLibrary
-import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
@@ -66,16 +65,13 @@ kotlin {
     pod("MapLibre", libs.versions.maplibre.ios.get())
   }
 
+  compilerOptions {
+    allWarningsAsErrors = true
+    freeCompilerArgs.addAll("-Xexpect-actual-classes", "-Xconsistent-data-class-copy-visibility")
+  }
+
   sourceSets {
-    all {
-      compilerOptions {
-        freeCompilerArgs.apply {
-          add("-Xexpect-actual-classes")
-          add("-Xconsistent-data-class-copy-visibility")
-        }
-      }
-      languageSettings { optIn("androidx.compose.material3.ExperimentalMaterial3Api") }
-    }
+    all { languageSettings { optIn("androidx.compose.material3.ExperimentalMaterial3Api") } }
 
     commonMain.dependencies {
       implementation(compose.components.resources)
@@ -116,10 +112,7 @@ kotlin {
 
 compose.resources { packageOfResClass = "dev.sargunv.maplibrecompose.demoapp.generated" }
 
-composeCompiler {
-  reportsDestination = layout.buildDirectory.dir("compose/reports")
-  featureFlags = setOf(ComposeFeatureFlag.StrongSkipping)
-}
+composeCompiler { reportsDestination = layout.buildDirectory.dir("compose/reports") }
 
 spotless {
   kotlinGradle { ktfmt().googleStyle() }

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -2,7 +2,6 @@
 
 import fr.brouillard.oss.jgitver.Strategies
 import org.jetbrains.compose.ExperimentalComposeLibrary
-import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
@@ -83,16 +82,14 @@ kotlin {
     pod("MapLibre", libs.versions.maplibre.ios.get())
   }
 
+  compilerOptions {
+    allWarningsAsErrors = true
+    freeCompilerArgs.addAll("-Xexpect-actual-classes", "-Xconsistent-data-class-copy-visibility")
+  }
+
   sourceSets {
-    all {
-      compilerOptions {
-        freeCompilerArgs.apply {
-          add("-Xexpect-actual-classes")
-          add("-Xconsistent-data-class-copy-visibility")
-        }
-      }
-      languageSettings { optIn("kotlinx.cinterop.ExperimentalForeignApi") }
-    }
+    filter { it.name.matches(Regex("ios.*Main")) }
+      .forEach { it.languageSettings { optIn("kotlinx.cinterop.ExperimentalForeignApi") } }
 
     commonMain.dependencies {
       api(compose.runtime)
@@ -121,10 +118,7 @@ kotlin {
   }
 }
 
-composeCompiler {
-  reportsDestination = layout.buildDirectory.dir("compose/reports")
-  featureFlags = setOf(ComposeFeatureFlag.StrongSkipping)
-}
+composeCompiler { reportsDestination = layout.buildDirectory.dir("compose/reports") }
 
 spotless {
   kotlinGradle { ktfmt().googleStyle() }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/PlatformUtils.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/util/PlatformUtils.kt
@@ -12,7 +12,9 @@ public actual object PlatformUtils {
     val context = LocalContext.current
     val display =
       if (Build.VERSION.SDK_INT >= 30) context.display
-      else (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+      else
+        @Suppress("DEPRECATION")
+        (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
     return display?.refreshRate ?: 0f
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -44,8 +44,7 @@ public interface ExpressionScope {
     get() = this as Expression<Dp>
 
   @Suppress("UNCHECKED_CAST")
-  public val Expression<Dp>.value: Expression<Number>
-    get() = this as Expression<Number>
+  public fun Expression<Dp>.asNumber(): Expression<Number> = this as Expression<Number>
 
   // expressions: https://maplibre.org/maplibre-style-spec/expressions/
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/LayerPropertyEnum.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/LayerPropertyEnum.kt
@@ -3,8 +3,8 @@ package dev.sargunv.maplibrecompose.core.expression
 import androidx.compose.runtime.Immutable
 import dev.sargunv.maplibrecompose.core.expression.Expression.Companion.const
 
-internal interface LayerPropertyEnum {
-  val expr: Expression<String>
+public interface LayerPropertyEnum {
+  public val expr: Expression<String>
 }
 
 /** Frame of reference for offsetting geometry */


### PR DESCRIPTION
one api change, `Expression<Dp>.value` is now `Expression<Dp>.asNumber()` to avoid a shadowing warning