### PR TITLE
Expressions documentation and refinement

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -63,7 +63,7 @@ object ClusteredPointsDemo : Demo {
           rememberGeoJsonSource(
             "bikes",
             gbfsData,
-            GeoJsonOptions(cluster = true, clusterMaxZoom = 16, clusterRadius = 32),
+            GeoJsonOptions(cluster = true, clusterRadius = 32, clusterMaxZoom = 16),
           )
 
         CircleLayer(

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/CircleLayer.kt
@@ -29,7 +29,9 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The `feature-state` expression is not supported in filter expressions.
+ *   levels. The
+ *   [featureState][dev.sargunv.maplibrecompose.core.expression.ExpressionScope.featureState]
+ *   expression is not supported in filter expressions.
  * @param visible Whether the layer should be displayed.
  * @param sortKey Sorts features within this layer in ascending order based on this value. Features
  *   with a higher sort key will appear above features with a lower sort key.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillExtrusionLayer.kt
@@ -27,7 +27,9 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The `feature-state` expression is not supported in filter expressions.
+ *   levels. The
+ *   [featureState][dev.sargunv.maplibrecompose.core.expression.ExpressionScope.featureState]
+ *   expression is not supported in filter expressions.
  * @param visible Whether the layer should be displayed.
  * @param translate The geometry's offset relative to the [translateAnchor]. Negative numbers
  *   indicate left and up (on the flat plane), respectively.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillLayer.kt
@@ -26,7 +26,9 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The `feature-state` expression is not supported in filter expressions.
+ *   levels. The
+ *   [featureState][dev.sargunv.maplibrecompose.core.expression.ExpressionScope.featureState]
+ *   expression is not supported in filter expressions.
  * @param visible Whether the layer should be displayed.
  * @param sortKey Sorts features within this layer in ascending order based on this value. Features
  *   with a higher sort key will appear above features with a lower sort key.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HeatmapLayer.kt
@@ -26,7 +26,9 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The `feature-state` expression is not supported in filter expressions.
+ *   levels. The
+ *   [featureState][dev.sargunv.maplibrecompose.core.expression.ExpressionScope.featureState]
+ *   expression is not supported in filter expressions.
  * @param visible Whether the layer should be displayed.
  * @param color Defines the color of each pixel based on its density value in a heatmap. Should be
  *   an expression that uses [heatmapDensity] as input.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/LineLayer.kt
@@ -31,7 +31,9 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The `feature-state` expression is not supported in filter expressions.
+ *   levels. The
+ *   [featureState][dev.sargunv.maplibrecompose.core.expression.ExpressionScope.featureState]
+ *   expression is not supported in filter expressions.
  * @param visible Whether the layer should be displayed.
  * @param sortKey Sorts features within this layer in ascending order based on this value. Features
  *   with a higher sort key will appear above features with a lower sort key.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -44,7 +44,9 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The `feature-state` expression is not supported in filter expressions.
+ *   levels. The
+ *   [featureState][dev.sargunv.maplibrecompose.core.expression.ExpressionScope.featureState]
+ *   expression is not supported in filter expressions.
  * @param visible Whether the layer should be displayed.
  * @param sortKey Sorts features within this layer in ascending order based on this value. Features
  *   with a higher sort key will appear above features with a lower sort key.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -146,7 +146,8 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *
  *   Ignored if [iconImage] is not specified.
  *
- *   **Note**: This property is not supported on native platforms, yet.
+ *   **Note**: This property is not supported on native platforms, yet, see
+ *   [maplibre-native#251](https://github.com/maplibre/maplibre-native/issues/251)**
  *
  * @param iconIgnorePlacement If true, other symbols can be visible even if they collide with the
  *   icon.
@@ -324,7 +325,8 @@ import dev.sargunv.maplibrecompose.core.source.Source
  *
  *   Ignored if [textField] is not specified.
  *
- *   **Note**: This property is not supported on native platforms, yet.
+ *   **Note**: This property is not supported on native platforms, yet, see
+ *   [maplibre-native#251](https://github.com/maplibre/maplibre-native/issues/251)**
  *
  * @param textIgnorePlacement If true, other symbols can be visible even if they collide with the
  *   text.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -48,7 +48,7 @@ public interface ExpressionScope {
 
   // expressions: https://maplibre.org/maplibre-style-spec/expressions/
 
-  // variable binding
+  //region Variable binding
 
   /**
    * Binds expressions to named variables, which can then be referenced in the result expression
@@ -60,7 +60,9 @@ public interface ExpressionScope {
   /** References variable bound using [let]. */
   public fun <T> `var`(name: String): Expression<T> = callFn("var", const(name))
 
-  // types
+  //endregion
+
+  //region Types
 
   /** Produces a literal array value. */
   public fun <T> literal(values: List<Expression<T>>): Expression<List<T>> =
@@ -244,7 +246,9 @@ public interface ExpressionScope {
   public fun toColor(value: Expression<*>, vararg fallbacks: Expression<*>): Expression<Color> =
     callFn("to-color", value, *fallbacks)
 
-  // lookup
+  //endregion
+
+  //region Lookup
 
   /** Retrieves an item from an array. */
   public fun <T> at(index: Expression<Number>, array: Expression<List<T>>): Expression<T> =
@@ -365,7 +369,9 @@ public interface ExpressionScope {
   @JvmName("lengthOfList")
   public fun length(value: Expression<List<*>>): Expression<Number> = callFn("length", value)
 
-  // decision
+  //endregion
+
+  //region Decision
 
   /**
    * Selects the first output whose corresponding test condition evaluates to true, or the fallback
@@ -576,7 +582,10 @@ public interface ExpressionScope {
   public fun within(geometry: Expression<Geometry>): Expression<Boolean> =
     callFn("within", geometry)
 
-  // ramps, scales, curves
+  //endregion
+
+  //region Ramps, Scales, Curves
+
 
   public fun <Output> step(
     input: Expression<Number>,
@@ -643,7 +652,9 @@ public interface ExpressionScope {
     y2: Expression<Number>,
   ): Expression<TInterpolationType> = callFn("cubic-bezier", x1, y1, x2, y2)
 
-  // math
+  //endregion
+
+  //region Math
 
   public fun ln2(): Expression<Number> = callFn("ln2")
 
@@ -751,7 +762,9 @@ public interface ExpressionScope {
 
   public fun distance(value: Expression<Geometry>): Expression<Number> = callFn("distance", value)
 
-  // color
+  //endregion
+
+  //region Color
 
   public fun toRgba(color: Expression<Color>): Expression<List<Number>> = callFn("to-rgba", color)
 
@@ -768,7 +781,9 @@ public interface ExpressionScope {
     blue: Expression<Number>,
   ): Expression<Color> = callFn("rgb", red, green, blue)
 
-  // feature data
+  //endregion
+
+  //region Feature data
 
   public fun <T> properties(): Expression<Map<String, T>> = callFn("properties")
 
@@ -783,15 +798,21 @@ public interface ExpressionScope {
 
   public fun <T> accumulated(key: Expression<String>): Expression<T> = callFn("accumulated", key)
 
-  // zoom
+  //endregion
+
+  //region Zoom
 
   public fun zoom(): Expression<Number> = callFn("zoom")
 
-  // heatmap
+  //endregion
+
+  //region Heatmap
 
   public fun heatmapDensity(): Expression<Number> = callFn("heatmap-density")
 
-  // string
+  //endregion
+
+  //region String
 
   public fun isSupportedScript(script: Expression<String>): Expression<Boolean> =
     callFn("is-supported-script", script)
@@ -806,7 +827,9 @@ public interface ExpressionScope {
   public fun resolvedLocale(collator: Expression<TCollator>): Expression<String> =
     callFn("resolved-locale", collator)
 
-  // utils
+  //endregion
+
+  //region Utils
 
   @Suppress("UNCHECKED_CAST")
   private fun <Return> callFn(function: String, vararg args: Expression<*>) =
@@ -825,4 +848,6 @@ public interface ExpressionScope {
   private fun <T> List<T>.foldToArgs(block: MutableList<Expression<*>>.(element: T) -> Unit) =
     fold(mutableListOf<Expression<*>>()) { acc, element -> acc.apply { block(element) } }
       .toTypedArray()
+
+  //endregion
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -1102,10 +1102,9 @@ public interface ExpressionScope {
    */
   public fun downcase(string: Expression<String>): Expression<String> = callFn("downcase", string)
 
-  /** Returns a string consisting of the concatenation of the [strings] expressions. */
-  public fun concat(vararg strings: Expression<String>): Expression<String> =
-    callFn("concat", *strings)
-
+  /** Concatenates this string expression with [other]. */
+  public operator fun Expression<String>.plus(other: Expression<String>): Expression<String> =
+    callFn("concat", this, other)
 
   /**
    * Returns the IETF language tag of the locale being used by the provided [collator]. This can be

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -529,12 +529,20 @@ public interface ExpressionScope {
   public fun <T> coalesce(vararg values: Expression<T?>): Expression<T> =
     callFn("coalesce", *values)
 
-  /**
-   * Returns whether this expression is equal to [other].
-   *
-   * The inputs must be Numbers, Strings, or Booleans, and both of the same type.
-   */
-  public infix fun Expression<*>.eq(other: Expression<*>): Expression<Boolean> =
+  /** Returns whether this expression is equal to [other]. */
+  public infix fun Expression<Boolean>.eq(other: Expression<Boolean>): Expression<Boolean> =
+    callFn("==", this, other)
+
+  /** Returns whether this expression is equal to [other]. */
+  public infix fun Expression<String>.eq(other: Expression<String>): Expression<Boolean> =
+    callFn("==", this, other)
+
+  /** Returns whether this expression is equal to [other]. */
+  public infix fun Expression<Number>.eq(other: Expression<Number>): Expression<Boolean> =
+    callFn("==", this, other)
+
+  /** Returns whether this expression is equal to [other]. */
+  public infix fun Expression<Dp>.eq(other: Expression<Dp>): Expression<Boolean> =
     callFn("==", this, other)
 
   /**
@@ -548,12 +556,20 @@ public interface ExpressionScope {
     collator: Expression<TCollator>? = null,
   ): Expression<Boolean> = callFn("==", left, right, *buildArgs { collator?.let { add(it) } })
 
-  /**
-   * Returns whether this expression is not equal to [other].
-   *
-   * The inputs must be Numbers, Strings, or Booleans, and both of the same type.
-   */
-  public infix fun Expression<*>.neq(other: Expression<*>): Expression<Boolean> =
+  /** Returns whether this expression is not equal to [other]. */
+  public infix fun Expression<Boolean>.neq(other: Expression<Boolean>): Expression<Boolean> =
+    callFn("!=", this, other)
+
+  /** Returns whether this expression is not equal to [other]. */
+  public infix fun Expression<String>.neq(other: Expression<String>): Expression<Boolean> =
+    callFn("!=", this, other)
+
+  /** Returns whether this expression is not equal to [other]. */
+  public infix fun Expression<Number>.neq(other: Expression<Number>): Expression<Boolean> =
+    callFn("!=", this, other)
+
+  /** Returns whether this expression is not equal to [other]. */
+  public infix fun Expression<Dp>.neq(other: Expression<Dp>): Expression<Boolean> =
     callFn("!=", this, other)
 
   /**

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -1047,16 +1047,36 @@ public interface ExpressionScope {
 
   //region String
 
+  /**
+   * Returns true if the input string is expected to render legibly. Returns false if the input
+   * string contains sections that cannot be rendered without potential loss of meaning (e.g. Indic
+   * scripts that require complex text shaping
+   */
   public fun isSupportedScript(script: Expression<String>): Expression<Boolean> =
     callFn("is-supported-script", script)
 
+  /**
+   * Returns the input [string] converted to uppercase. Follows the Unicode Default Case Conversion
+   * algorithm and the locale-insensitive case mappings in the Unicode Character Database.
+   */
   public fun upcase(string: Expression<String>): Expression<String> = callFn("upcase", string)
 
+  /**
+   * Returns the input [string] converted to lowercase. Follows the Unicode Default Case Conversion
+   * algorithm and the locale-insensitive case mappings in the Unicode Character Database.
+   */
   public fun downcase(string: Expression<String>): Expression<String> = callFn("downcase", string)
 
+  /** Returns a string consisting of the concatenation of the [strings] expressions. */
   public fun concat(vararg strings: Expression<String>): Expression<String> =
     callFn("concat", *strings)
 
+
+  /**
+   * Returns the IETF language tag of the locale being used by the provided [collator]. This can be
+   * used to determine the default system locale, or to determine if a requested locale was
+   * successfully loaded.
+   */
   public fun resolvedLocale(collator: Expression<TCollator>): Expression<String> =
     callFn("resolved-locale", collator)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -757,8 +757,18 @@ public interface ExpressionScope {
 
   //region Color
 
+  /**
+   * Returns a four-element list, containing the [color]'s red, green, blue, and alpha components,
+   * in that order.
+   */
   public fun toRgba(color: Expression<Color>): Expression<List<Number>> = callFn("to-rgba", color)
 
+  /**
+   * Creates a color value from [red], [green], and [blue] components, which must range between 0
+   * and 255, and an [alpha] component which must range between 0 and 1.
+   *
+   * If any component is out of range, the expression is an error.
+   */
   public fun rgba(
     red: Expression<Number>,
     green: Expression<Number>,
@@ -766,6 +776,12 @@ public interface ExpressionScope {
     alpha: Expression<Number>,
   ): Expression<Color> = callFn("rgba", red, green, blue, alpha)
 
+  /**
+   * Creates a color value from [red], [green], and [blue] components, which must range between 0
+   * and 255, and an alpha component of 1.
+   *
+   * If any component is out of range, the expression is an error.
+   */
   public fun rgb(
     red: Expression<Number>,
     green: Expression<Number>,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -186,23 +186,29 @@ public interface ExpressionScope {
   )
 
   /**
-   * Returns an image type for use in icon-image, *-pattern entries and as a section in the [format]
-   * expression. If set, the image argument will check that the requested image exists in the style
-   * and will return either the resolved image name or null, depending on whether or not the image
+   * Returns an image type for use in `iconImage` (see
+   * [SymbolLayer][dev.sargunv.maplibrecompose.compose.layer.SymbolLayer]), `pattern` entries (see
+   * [BackgroundLayer][dev.sargunv.maplibrecompose.compose.layer.BackgroundLayer],
+   * [FillLayer][dev.sargunv.maplibrecompose.compose.layer.FillLayer],
+   * [FillExtrusionLayer][dev.sargunv.maplibrecompose.compose.layer.FillExtrusionLayer],
+   * [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer])  and as a section in the
+   * [format] expression.
+   *
+   * If set, the image argument will check that the requested image exists in the style
+   * and will return either the resolved image name or `null`, depending on whether or not the image
    * is currently in the style. This validation process is synchronous and requires the image to
    * have been added to the style before requesting it in the image argument.
    */
   public fun image(value: Expression<String>): Expression<TResolvedImage> = callFn("image", value)
 
   /**
-   * Converts the input number into a string representation using the providing formatting rules. If
-   * set, the locale argument specifies the locale to use, as a BCP 47 language tag. If set, the
-   * currency argument specifies an ISO 4217 code to use for currency-style formatting. If set, the
-   * min-fraction-digits and max-fraction-digits arguments specify the minimum and maximum number of
-   * fractional digits to include.
+   * Converts this number into a string representation using the provided formatting rules.
+   * @param locale BCP 47 language tag for which locale to use
+   * @param currency an ISO 4217 code to use for currency-style formatting
+   * @param minFractionDigits minimum fractional digits to include
+   * @param maxFractionDigits maximum fractional digits to include
    */
-  public fun numberFormat(
-    number: Expression<Number>,
+  public fun Expression<Number>.numberFormat(
     locale: Expression<String>? = null,
     currency: Expression<String>? = null,
     minFractionDigits: Expression<Number>? = null,
@@ -210,7 +216,7 @@ public interface ExpressionScope {
   ): Expression<String> =
     callFn(
       "number-format",
-      number,
+      this,
       buildOptions {
         locale?.let { put("locale", it) }
         currency?.let { put("currency", it) }
@@ -233,7 +239,7 @@ public interface ExpressionScope {
    * Otherwise, the input is converted to a string in the format specified by the JSON.stringify
    * function of the ECMAScript Language Specification.
    */
-  public fun Expression<*>.toStringExpression(): Expression<String> = callFn("to-string", this)
+  public fun Expression<*>.convertToString(): Expression<String> = callFn("to-string", this)
 
   /**
    * Converts this expression to a number.
@@ -246,7 +252,7 @@ public interface ExpressionScope {
    * in order until the first successful conversion is obtained. If none of the inputs can be
    * converted, the expression is an error.
    */
-  public fun Expression<*>.toNumberExpression(vararg fallbacks: Expression<*>): Expression<Number> =
+  public fun Expression<*>.convertToNumber(vararg fallbacks: Expression<*>): Expression<Number> =
     callFn("to-number", this, *fallbacks)
 
   /**
@@ -255,7 +261,7 @@ public interface ExpressionScope {
    * The result is `false` when then this is an empty string, `0`, `false`,`null` or `NaN`;
    * otherwise it is `true`.
    */
-  public fun Expression<*>.toBooleanExpression(): Expression<Boolean> = callFn("to-boolean", this)
+  public fun Expression<*>.convertToBoolean(): Expression<Boolean> = callFn("to-boolean", this)
 
   /**
    * Converts this expression to a color expression.
@@ -264,7 +270,7 @@ public interface ExpressionScope {
    * order until the first successful conversion is obtained. If none of the inputs can be
    * converted, the expression is an error.
    */
-  public fun Expression<*>.toColorExpression(vararg fallbacks: Expression<*>): Expression<Color> =
+  public fun Expression<*>.convertToColor(vararg fallbacks: Expression<*>): Expression<Color> =
     callFn("to-color", this, *fallbacks)
 
   //endregion
@@ -276,19 +282,19 @@ public interface ExpressionScope {
   public operator fun <T> Expression<List<T>>.get(index: Expression<Number>): Expression<T> =
     callFn("at", index, this)
 
-  /** Returns whether this list contains an [item]. */
+  /** Returns whether this list contains the [item]. */
   @JvmName("containsList")
   public fun Expression<List<*>>.contains(item: Expression<*>): Expression<Boolean> =
     callFn("in", item, this)
 
-  /** Returns whether this string contains a [substring]. */
+  /** Returns whether this string contains the [substring]. */
   @JvmName("containsString")
   public fun Expression<String>.contains(substring: Expression<String>): Expression<Boolean> =
     callFn("in", substring, this)
 
   /**
-   * Returns the first index at which a [substring] is found in this string, or -1 if it cannot be
-   * found. Accepts an optional [startIndex] from where to begin the search.
+   * Returns the first index at which the [substring] is located in this string, or `-1` if it
+   * cannot be found. Accepts an optional [startIndex] from where to begin the search.
    */
   @JvmName("indexOfString")
   public fun Expression<String>.indexOf(
@@ -304,8 +310,8 @@ public interface ExpressionScope {
   }
 
   /**
-   * Returns the first index at which an [item] is found in this list, or -1 if it cannot be found.
-   * Accepts an optional [startIndex] from where to begin the search.
+   * Returns the first index at which the [item] is located in this list, or `-1` if it cannot be
+   * found. Accepts an optional [startIndex] from where to begin the search.
    */
   @JvmName("indexOfList")
   public fun Expression<List<*>>.indexOf(
@@ -321,9 +327,10 @@ public interface ExpressionScope {
   }
 
   /**
-   * Returns a substring from this string from the [startIndex] (inclusive) to the [endIndex]
-   * (exclusive). If [endIndex] is not set or null, till the end of the string. A UTF-16 surrogate
-   * pair counts as a single position.
+   * Returns a substring from this string from the [startIndex] (inclusive) to the end of the
+   * string if [endIndex] is not specified or `null`, otherwise to [endIndex] (exclusive).
+   *
+   * A UTF-16 surrogate pair counts as a single position.
    */
   public fun Expression<String>.substring(
     startIndex: Expression<Number>,
@@ -338,8 +345,8 @@ public interface ExpressionScope {
   }
 
   /**
-   * Returns the items in this list from the [startIndex] (inclusive) to the [endIndex] (exclusive).
-   * If [endIndex] is not set or null, till the end of the list.
+   * Returns the items in this list from the [startIndex] (inclusive) to the end of this list if
+   * [endIndex] is not specified or `null`, otherwise to [endIndex] (exclusive).
    */
   public fun <T> Expression<List<T>>.slice(
     startIndex: Expression<Number>,
@@ -354,8 +361,8 @@ public interface ExpressionScope {
   }
 
   /**
-   * Returns the value corresponding to the given [key] in the current feature's properties or null
-   * if it is not present.
+   * Returns the value corresponding to the given [key] in the current feature's properties or
+   * `null` if it is not present.
    */
   public fun <T> get(key: Expression<String>): Expression<T> =
     callFn("get", key)
@@ -364,7 +371,7 @@ public interface ExpressionScope {
   public fun has(key: Expression<String>): Expression<Boolean> =
     callFn("has", key)
 
-  /** Returns the value corresponding the given [key] or null if it is not present in this map. */
+  /** Returns the value corresponding the given [key] or `null` if it is not present in this map. */
   public operator fun <T> Expression<Map<String, *>>.get(key: Expression<String>): Expression<T> =
     callFn("get", key, this)
 
@@ -372,7 +379,11 @@ public interface ExpressionScope {
   public fun Expression<Map<String, *>>.has(key: Expression<String>): Expression<Boolean> =
     callFn("has", key, this)
 
-  /** Gets the length of this string. A UTF-16 surrogate pair counts as a single position. */
+  /**
+   * Gets the length of this string.
+   *
+   * A UTF-16 surrogate pair counts as a single position.
+   */
   @JvmName("lengthOfString")
   public fun Expression<String>.length(): Expression<Number> = callFn("length", this)
 
@@ -512,8 +523,8 @@ public interface ExpressionScope {
     MatchBranch(Expression.ofList(this.map { const(it.toFloat()) }), output)
 
   /**
-   * Evaluates each expression in turn until the first non-null value is obtained, and returns that
-   * value.
+   * Evaluates each expression in [values] in turn until the first non-null value is obtained, and
+   * returns that value.
    */
   public fun <T> coalesce(vararg values: Expression<T?>): Expression<T> =
     callFn("coalesce", *values)

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -137,7 +137,7 @@ public interface ExpressionScope {
 
   /**
    * Returns a collator for use in locale-dependent comparison operations. The [caseSensitive] and
-   * [diacriticSensitive] options default to false. The [locale] argument specifies the IETF
+   * [diacriticSensitive] options default to `false`. The [locale] argument specifies the IETF
    * language tag of the locale to use. If none is provided, the default locale is used. If the
    * requested locale is not available, the collator will use a system-defined fallback locale. Use
    * [resolvedLocale] to test the results of locale fallback behavior.
@@ -157,9 +157,9 @@ public interface ExpressionScope {
     )
 
   /**
-   * Returns a formatted string for displaying mixed-format text in the text-field property. The
-   * input may contain a string literal or expression, including an 'image' expression. Strings may
-   * be followed by a style override object that supports the following properties:
+   * Returns a formatted string for displaying mixed-format text in the `textField` property (see
+   * [SymbolLayer][dev.sargunv.maplibrecompose.compose.layer.SymbolLayer]). The input may contain a
+   * string literal or expression, including an 'image' expression.
    */
   public fun format(vararg sections: Pair<Expression<*>, FormatStyle>): Expression<TFormatted> =
     callFn(

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -746,7 +746,9 @@ public interface ExpressionScope {
    * [input], or the [fallback] if the input is less than the first stop.
    *
    * Example:
-   * `step(zoom(), const(0), 10 to const(2.5), 20 to const(10.5))`
+   * ```
+   * step(zoom(), const(0), 10 to const(2.5), 20 to const(10.5))
+   * ```
    *
    * returns 0 if the zoom is less than 10, 2.5 if the zoom is between 10 and less than 20, 10.5 if
    * the zoom is greater than or equal 20.
@@ -844,8 +846,10 @@ public interface ExpressionScope {
   /** Interpolates linearly between the pairs of stops. */
   public fun linear(): Expression<TInterpolationType> = callFn("linear")
 
-  /** Interpolates using the cubic bezier curve defined by the given control points between the
-   *  pairs of stops. */
+  /**
+   * Interpolates using the cubic bezier curve defined by the given control points between the
+   * pairs of stops.
+   */
   public fun cubicBezier(
     x1: Expression<Number>,
     y1: Expression<Number>,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -1008,17 +1008,35 @@ public interface ExpressionScope {
 
   //region Feature data
 
+  /**
+   * Gets the feature properties object. Note that in some cases, it may be more efficient to use
+   * `get("property_name")` directly.
+   */
   public fun <T> properties(): Expression<Map<String, T>> = callFn("properties")
 
   public fun <T> featureState(key: Expression<String>): Expression<T> = callFn("feature-state", key)
 
+  /**
+   * Gets the feature's geometry type as a string: "Point", "MultiPoint", "LineString",
+   * "MultiLineString", "Polygon" or "MultiPolygon".
+   */
   public fun geometryType(): Expression<String> = callFn("geometry-type")
 
+  /** Gets the feature's id, if it has one. */
   public fun <T> id(): Expression<T> = callFn("id")
 
+  /**
+   * Gets the progress along a gradient line. Can only be used in the `gradient` property of a line
+   * layer, see [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer].
+   */
   public fun lineProgress(value: Expression<Number>): Expression<Number> =
     callFn("line-progress", value)
 
+  /**
+   * Gets the value of a cluster property accumulated so far. Can only be used in the
+   * `clusterProperties` option of a clustered GeoJSON source, see
+   * [GeoJsonOptions][dev.sargunv.maplibrecompose.core.source.GeoJsonOptions].
+   */
   public fun <T> accumulated(key: Expression<String>): Expression<T> = callFn("accumulated", key)
 
   //endregion

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -667,13 +667,13 @@ public interface ExpressionScope {
     collator: Expression<TCollator>? = null,
   ): Expression<Boolean> = callFn("<=", left, right, *buildArgs { collator?.let { add(it) } })
 
-  /** Returns whether all of the [expressions] are `true`. */
-  public fun all(vararg expressions: Expression<Boolean>): Expression<Boolean> =
-    callFn("all", *expressions)
+  /** Returns whether both this and [other] expressions are true. */
+  public infix fun Expression<Boolean>.and(other: Expression<Boolean>): Expression<Boolean> =
+    callFn("all", this, other)
 
-  /** Returns whether any of the [expressions] are `true`. */
-  public fun any(vararg expressions: Expression<Boolean>): Expression<Boolean> =
-    callFn("any", *expressions)
+  /** Returns whether any of this or the [other] expressions are true. */
+  public infix fun Expression<Boolean>.or(other: Expression<Boolean>): Expression<Boolean> =
+    callFn("any", this, other)
 
   /** Negates this expression. */
   @JvmName("notOperator")

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -336,8 +336,8 @@ public interface ExpressionScope {
   }
 
   /**
-   * Retrieves a property value from the current feature's properties, or from another object if a
-   * second argument is provided. Returns null if the requested property is missing.
+   * Retrieves a property value [key] from the current feature's properties, or from another object
+   * [obj] if a second argument is provided. Returns null if the requested property is missing.
    */
   public fun <T> get(
     key: Expression<String>,
@@ -348,8 +348,8 @@ public interface ExpressionScope {
   }
 
   /**
-   * Tests for the presence of an property value in the current feature's properties, or from
-   * another object if a second argument is provided.
+   * Tests for the presence of an property value [key] in the current feature's properties, or from
+   * another object [obj] if a second argument is provided.
    */
   public fun has(
     key: Expression<String>,
@@ -359,19 +359,13 @@ public interface ExpressionScope {
     return callFn("has", *args.toTypedArray())
   }
 
-  /**
-   * Gets the length of an array or string. In a string, a UTF-16 surrogate pair counts as a single
-   * position.
-   */
+  /** Gets the length of a [string]. A UTF-16 surrogate pair counts as a single position. */
   @JvmName("lengthOfString")
-  public fun length(value: Expression<String>): Expression<Number> = callFn("length", value)
+  public fun length(string: Expression<String>): Expression<Number> = callFn("length", string)
 
-  /**
-   * Gets the length of an array or string. In a string, a UTF-16 surrogate pair counts as a single
-   * position.
-   */
+  /** Gets the length of a [list]. */
   @JvmName("lengthOfList")
-  public fun length(value: Expression<List<*>>): Expression<Number> = callFn("length", value)
+  public fun length(list: Expression<List<*>>): Expression<Number> = callFn("length", list)
 
   //endregion
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -586,7 +586,18 @@ public interface ExpressionScope {
 
   //region Ramps, Scales, Curves
 
+  /**
+   * Produces discrete, stepped results by evaluating a piecewise-constant function defined by pairs
+   * of input and output values ([stops]). Returns the output value of the stop just less than the
+   * [input], or the [fallback] if the input is less than the first stop.
 
+   * Example:
+   *
+   * `step(zoom(), const(0), 10 to const(2.5), 20 to const(10.5))`
+   *
+   * returns 0 if the zoom is less than 10, 2.5 if the zoom is between 10 and less than 20, 10.5 if
+   * the zoom is greater than or equal 20.
+   * */
   public fun <Output> step(
     input: Expression<Number>,
     fallback: Expression<Output>,
@@ -622,29 +633,66 @@ public interface ExpressionScope {
         },
     )
 
+  /**
+   * Produces continuous, smooth results by interpolating between pairs of input and output values
+   * ([stops]), given the [input] value.
+   *
+   * Example:
+   *
+   * ```
+   * interpolate(
+   *   linear(), zoom(),
+   *   1 to const(Color.Red),
+   *   5 to const(Color.Blue),
+   *   10 to const(Color.Green)
+   * )
+   * ```
+   *
+   * interpolates linearly from red to blue between in zoom levels 1 to 5, then interpolates
+   * linearly from blue to green in zoom levels 5 to 10, which it where it remains until maximum
+   * zoom.
+   */
   public fun <Output> interpolate(
     type: Expression<TInterpolationType>,
     input: Expression<Number>,
     vararg stops: Pair<Number, Expression<Output>>,
   ): Expression<Output> = interpolateImpl("interpolate", type, input, *stops)
 
+  /**
+   * Produces continuous, smooth results by interpolating between pairs of input and output values
+   * ([stops]), given the [input] value. Works like [interpolate], but the interpolation is
+   * performed in the
+   * [Hue-Chroma-Luminance color space](https://en.wikipedia.org/wiki/HCL_color_space).
+   */
   public fun interpolateHcl(
     type: Expression<TInterpolationType>,
     input: Expression<Number>,
     vararg stops: Pair<Number, Expression<Color>>,
   ): Expression<Color> = interpolateImpl("interpolate-hcl", type, input, *stops)
 
+  /**
+   * Produces continuous, smooth results by interpolating between pairs of input and output values
+   * ([stops]), given the [input] value. Works like [interpolate], but the interpolation is
+   * performed in the [CIELAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space).
+   */
   public fun interpolateLab(
     type: Expression<TInterpolationType>,
     input: Expression<Number>,
     vararg stops: Pair<Number, Expression<Color>>,
   ): Expression<Color> = interpolateImpl("interpolate-lab", type, input, *stops)
 
+  /** Interpolates exponentially between the stops. [base] controls the rate at which the output
+   * increases: higher values make the output increase more towards the high end of the range. With
+   * values close to 1 the output increases linearly.
+   */
   public fun exponential(base: Expression<Number>): Expression<TInterpolationType> =
     callFn("exponential", base)
 
+  /** Interpolates linearly between the pairs of stops. */
   public fun linear(): Expression<TInterpolationType> = callFn("linear")
 
+  /** Interpolates using the cubic bezier curve defined by the given control points between the
+   *  pairs of stops. */
   public fun cubicBezier(
     x1: Expression<Number>,
     y1: Expression<Number>,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -281,19 +281,38 @@ public interface ExpressionScope {
     `in`(this, other)
 
   /**
-   * Returns the first position at which an item can be found in an array or a substring can be
-   * found in a string, or -1 if the input cannot be found. Accepts an optional index from where to
-   * begin the search. In a string, a UTF-16 surrogate pair counts as a single position.
+   * Returns the first position at which an [substring] can be found in a [string], or -1 if it
+   * cannot be found. Accepts an optional index from where to begin the search. A UTF-16 surrogate
+   * pair counts as a single position.
    */
+  @JvmName("indexOfString")
   public fun indexOf(
-    value: Expression<*>,
-    array: Expression<List<*>>,
-    start: Expression<Number>? = null,
+    substring: Expression<String>,
+    string: Expression<String>,
+    startIndex: Expression<Number>? = null,
   ): Expression<Number> {
     val args = buildList {
-      add(value)
-      add(array)
-      start?.let { add(it) }
+      add(substring)
+      add(string)
+      startIndex?.let { add(it) }
+    }
+    return callFn("index-of", *args.toTypedArray())
+  }
+
+  /**
+   * Returns the first position at which an [item] can be found in a [list], or -1 if it cannot be
+   * found. Accepts an optional index from where to begin the search.
+   */
+  @JvmName("indexOfList")
+  public fun indexOf(
+    item: Expression<*>,
+    list: Expression<List<*>>,
+    startIndex: Expression<Number>? = null,
+  ): Expression<Number> {
+    val args = buildList {
+      add(item)
+      add(list)
+      startIndex?.let { add(it) }
     }
     return callFn("index-of", *args.toTypedArray())
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -215,40 +215,52 @@ public interface ExpressionScope {
     )
 
   /**
-   * Converts the input value to a string. If the input is null, the result is "". If the input is a
-   * boolean, the result is "true" or "false". If the input is a number, it is converted to a string
-   * as specified by the "NumberToString" algorithm of the ECMAScript Language Specification. If the
-   * input is a color, it is converted to a string of the form "rgba(r,g,b,a)", where r, g, and b
-   * are numerals ranging from 0 to 255, and a ranges from 0 to 1. Otherwise, the input is converted
-   * to a string in the format specified by the JSON.stringify function of the ECMAScript Language
-   * Specification.
+   * Converts this expression to a string.
+   *
+   * If this is ...
+   * - `null`, the result is `""`
+   * - a boolean, the result is `"true"` or `"false"`
+   * - a number, it is converted to a string as specified by the "NumberToString" algorithm of the
+   *   ECMAScript Language Specification.
+   * - a color, it is converted to a string of the form `"rgba(r,g,b,a)"`, where `r`, `g`, and `b`
+   *   are numerals ranging from 0 to 255, and `a` ranges from 0 to 1.
+   *
+   * Otherwise, the input is converted to a string in the format specified by the JSON.stringify
+   * function of the ECMAScript Language Specification.
    */
-  public fun toString(value: Expression<*>): Expression<String> = callFn("to-string", value)
+  public fun Expression<*>.toStringExpression(): Expression<String> = callFn("to-string", this)
 
   /**
-   * Converts the input value to a number, if possible. If the input is null or false, the result
-   * is 0. If the input is true, the result is 1. If the input is a string, it is converted to a
-   * number as specified by the "ToNumber Applied to the String Type" algorithm of the ECMAScript
-   * Language Specification. If multiple values are provided, each one is evaluated in order until
-   * the first successful conversion is obtained. If none of the inputs can be converted, the
-   * expression is an error.
+   * Converts this expression to a number.
+   *
+   * If this expression is `null` or `false`, the result is `0`. If this is `true`, the result is
+   * `1`. If the input is a string, it is converted to a number as specified by the "ToNumber
+   * Applied to the String Type" algorithm of the ECMAScript Language Specification.
+   *
+   * In case this expression cannot be converted to a number, each of the [fallbacks] is evaluated
+   * in order until the first successful conversion is obtained. If none of the inputs can be
+   * converted, the expression is an error.
    */
-  public fun toNumber(value: Expression<*>, vararg fallbacks: Expression<*>): Expression<Number> =
-    callFn("to-number", value, *fallbacks)
+  public fun Expression<*>.toNumberExpression(vararg fallbacks: Expression<*>): Expression<Number> =
+    callFn("to-number", this, *fallbacks)
 
   /**
-   * Converts the input value to a boolean. The result is false when then input is an empty string,
-   * 0, false, null, or NaN; otherwise it is true.
+   * Converts this expression to a boolean expression.
+   *
+   * The result is `false` when then this is an empty string, `0`, `false`,`null` or `NaN`;
+   * otherwise it is `true`.
    */
-  public fun toBoolean(value: Expression<*>): Expression<Boolean> = callFn("to-boolean", value)
+  public fun Expression<*>.toBooleanExpression(): Expression<Boolean> = callFn("to-boolean", this)
 
   /**
-   * Converts the input value to a color. If multiple values are provided, each one is evaluated in
+   * Converts this expression to a color expression.
+   *
+   * In case this expression cannot be converted to a color, each of the [fallbacks] is evaluated in
    * order until the first successful conversion is obtained. If none of the inputs can be
    * converted, the expression is an error.
    */
-  public fun toColor(value: Expression<*>, vararg fallbacks: Expression<*>): Expression<Color> =
-    callFn("to-color", value, *fallbacks)
+  public fun Expression<*>.toColorExpression(vararg fallbacks: Expression<*>): Expression<Color> =
+    callFn("to-color", this, *fallbacks)
 
   //endregion
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -432,8 +432,8 @@ public interface ExpressionScope {
   @JvmName("matchStrings")
   public fun <T> match(
     input: Expression<String>,
-    fallback: Expression<T>,
     vararg branches: MatchBranch<String, T>,
+    fallback: Expression<T>,
   ): Expression<T> =
     callFn(
       "match",
@@ -457,8 +457,8 @@ public interface ExpressionScope {
   @JvmName("matchNumbers")
   public fun <T> match(
     input: Expression<Number>,
-    fallback: Expression<T>,
     vararg branches: MatchBranch<Number, T>,
+    fallback: Expression<T>,
   ): Expression<T> =
     callFn(
       "match",

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -452,7 +452,7 @@ public interface ExpressionScope {
    * )
    * ```
    *
-   * If the feature has a property  "building_type" with the value "residential", cyan is returned.
+   * If the feature has a property "building_type" with the value "residential", cyan is returned.
    * Otherwise, if the value of that property is either "commercial" or "industrial", yellow is
    * returned. If none of that is true, the fallback is returned, i.e. red.
    */
@@ -734,8 +734,7 @@ public interface ExpressionScope {
    * Returns whether the evaluated feature is fully contained inside the boundary of the given
    * [polygon].
    */
-  public fun within(polygon: Expression<Polygon>): Expression<Boolean> =
-    callFn("within", polygon)
+  public fun within(polygon: Expression<Polygon>): Expression<Boolean> = callFn("within", polygon)
 
   // endregion
 
@@ -745,9 +744,8 @@ public interface ExpressionScope {
    * Produces discrete, stepped results by evaluating a piecewise-constant function defined by pairs
    * of input and output values ([stops]). Returns the output value of the stop just less than the
    * [input], or the [fallback] if the input is less than the first stop.
-
-   * Example:
    *
+   * Example:
    * `step(zoom(), const(0), 10 to const(2.5), 20 to const(10.5))`
    *
    * returns 0 if the zoom is less than 10, 2.5 if the zoom is between 10 and less than 20, 10.5 if
@@ -793,7 +791,6 @@ public interface ExpressionScope {
    * ([stops]), given the [input] value.
    *
    * Example:
-   *
    * ```
    * interpolate(
    *   linear(), zoom(),

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import io.github.dellisd.spatialk.geojson.Geometry
+import io.github.dellisd.spatialk.geojson.MultiPolygon
 import io.github.dellisd.spatialk.geojson.Polygon
 import kotlin.jvm.JvmName
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -662,28 +662,19 @@ public interface ExpressionScope {
 
   public fun e(): Expression<Number> = callFn("e")
 
-  public fun sum(vararg numbers: Expression<Number>): Expression<Number> = callFn("+", *numbers)
-
-  @JvmName("sumDp")
-  public fun sum(vararg numbers: Expression<Dp>): Expression<Dp> = callFn("+", *numbers)
-
-  public fun product(vararg numbers: Expression<Number>): Expression<Number> = callFn("*", *numbers)
-
-  @JvmName("productDp")
-  public fun product(vararg numbers: Expression<Dp>): Expression<Dp> = callFn("*", *numbers)
-
   public operator fun Expression<Number>.plus(other: Expression<Number>): Expression<Number> =
-    sum(this, other)
+    callFn("+", this, other)
 
   @JvmName("plusDp")
-  public operator fun Expression<Dp>.plus(other: Expression<Dp>): Expression<Dp> = sum(this, other)
+  public operator fun Expression<Dp>.plus(other: Expression<Dp>): Expression<Dp> =
+    callFn("+", this, other)
 
   public operator fun Expression<Number>.times(other: Expression<Number>): Expression<Number> =
-    product(this, other)
+    callFn("*", this, other)
 
   @JvmName("timesDp")
   public operator fun Expression<Dp>.times(other: Expression<Dp>): Expression<Dp> =
-    product(this, other)
+    callFn("*", this, other)
 
   public operator fun Expression<Number>.minus(other: Expression<Number>): Expression<Number> =
     callFn("-", this, other)

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -962,35 +962,29 @@ public interface ExpressionScope {
   //region Color
 
   /**
-   * Returns a four-element list, containing the [color]'s red, green, blue, and alpha components,
+   * Returns a four-element list, containing the color's red, green, blue, and alpha components,
    * in that order.
    */
-  public fun toRgba(color: Expression<Color>): Expression<List<Number>> = callFn("to-rgba", color)
+  public fun Expression<Color>.toRgbaComponents(): Expression<List<Number>> =
+    callFn("to-rgba", this)
 
   /**
    * Creates a color value from [red], [green], and [blue] components, which must range between 0
-   * and 255, and an [alpha] component which must range between 0 and 1.
+   * and 255, and optionally an [alpha] component which must range between 0 and 1.
    *
    * If any component is out of range, the expression is an error.
    */
-  public fun rgba(
+  public fun rgbColor(
     red: Expression<Number>,
     green: Expression<Number>,
     blue: Expression<Number>,
-    alpha: Expression<Number>,
-  ): Expression<Color> = callFn("rgba", red, green, blue, alpha)
-
-  /**
-   * Creates a color value from [red], [green], and [blue] components, which must range between 0
-   * and 255, and an alpha component of 1.
-   *
-   * If any component is out of range, the expression is an error.
-   */
-  public fun rgb(
-    red: Expression<Number>,
-    green: Expression<Number>,
-    blue: Expression<Number>,
-  ): Expression<Color> = callFn("rgb", red, green, blue)
+    alpha: Expression<Number>? = null,
+  ): Expression<Color> =
+    if (alpha != null) {
+      callFn("rgba", red, green, blue, alpha)
+    } else {
+      callFn("rgb", red, green, blue)
+    }
 
   //endregion
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -14,6 +14,8 @@ public interface ExpressionScope {
 
   // basic types: https://maplibre.org/maplibre-style-spec/types/
 
+  //region Literals
+
   public fun const(string: String): Expression<String> = Expression.ofString(string)
 
   public fun <T : LayerPropertyEnum> const(value: T): Expression<T> =
@@ -49,6 +51,7 @@ public interface ExpressionScope {
 
   // expressions: https://maplibre.org/maplibre-style-spec/expressions/
 
+  //endregion
   //region Variable binding
 
   /**

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -736,6 +736,13 @@ public interface ExpressionScope {
    */
   public fun within(polygon: Expression<Polygon>): Expression<Boolean> = callFn("within", polygon)
 
+  /**
+   * Returns whether the evaluated feature is fully contained inside the boundary of the given
+   * [polygon].
+   */
+  public fun within(polygon: Expression<MultiPolygon>): Expression<Boolean> =
+    callFn("within", polygon)
+
   // endregion
 
   // region Ramps, Scales, Curves

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -1042,7 +1042,7 @@ public interface ExpressionScope {
 
   /**
    * **Note: Not supported on native platforms. See
-   * [ticket #1698](https://github.com/maplibre/maplibre-native/issues/1698)**
+   * [maplibre-native#1698](https://github.com/maplibre/maplibre-native/issues/1698)**
    *
    * Retrieves a property value from the current feature's state. Returns `null` if the requested
    * property is not present on the feature's state.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -161,6 +161,17 @@ public interface ExpressionScope {
    * Returns a formatted string for displaying mixed-format text in the `textField` property (see
    * [SymbolLayer][dev.sargunv.maplibrecompose.compose.layer.SymbolLayer]). The input may contain a
    * string literal or expression, including an 'image' expression.
+   *
+   * Example:
+   * ```
+   * format(
+   *   get("name").substring(const(0), const(1)).uppercase() to FormatStyle(textScale = const(1.5)),
+   *   get("name").substring(const(1)) to FormatStyle(),
+   * )
+   * ```
+   *
+   * Capitalizes the first letter of the features' property "name" and formats it to be extra-large,
+   * the rest of the name is written normally.
    */
   public fun format(vararg sections: Pair<Expression<*>, FormatStyle>): Expression<TFormatted> =
     callFn(
@@ -177,6 +188,7 @@ public interface ExpressionScope {
       },
     )
 
+  /** Use a string as a formatted value without any extra formatting */
   public fun format(value: Expression<String>): Expression<TFormatted> =
     callFn("format", value, buildOptions {})
 
@@ -803,16 +815,15 @@ public interface ExpressionScope {
    * Example:
    * ```
    * interpolate(
-   *   linear(), zoom(),
-   *   1 to const(Color.Red),
-   *   5 to const(Color.Blue),
-   *   10 to const(Color.Green)
+   *   exponential(2), zoom(),
+   *   16 to const(1),
+   *   24 to const(256),
    * )
    * ```
    *
-   * interpolates linearly from red to blue between in zoom levels 1 to 5, then interpolates
-   * linearly from blue to green in zoom levels 5 to 10, which it where it remains until maximum
-   * zoom.
+   * interpolates exponentially from 1 to 256 in zoom levels 16 to 24. Below zoom 16, it is 1, above
+   * zoom 24, it is 256. Applied to for example line width, this has the visual effect that the line
+   * stays the same width in meters on the map (rather than on the viewport).
    */
   public fun <Output> interpolate(
     type: Expression<TInterpolationType>,
@@ -825,6 +836,20 @@ public interface ExpressionScope {
    * ([stops]), given the [input] value. Works like [interpolate], but the interpolation is
    * performed in the
    * [Hue-Chroma-Luminance color space](https://en.wikipedia.org/wiki/HCL_color_space).
+   *
+   * Example:
+   * ```
+   * interpolateHcl(
+   *   linear(), zoom(),
+   *   1 to const(Color.Red),
+   *   5 to const(Color.Blue),
+   *   10 to const(Color.Green)
+   * )
+   * ```
+   *
+   * interpolates linearly from red to blue between in zoom levels 1 to 5, then interpolates
+   * linearly from blue to green in zoom levels 5 to 10, which it where it remains until maximum
+   * zoom.
    */
   public fun interpolateHcl(
     type: Expression<TInterpolationType>,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -299,38 +299,38 @@ public interface ExpressionScope {
   }
 
   /**
-   * Returns a substring from a string from a specified start index, or between a start index and an
-   * end index if set. The return value is inclusive of the start index but not of the end index. A
-   * UTF-16 surrogate pair counts as a single position.
+   * Returns a substring from a [string] from a specified start index, or between a [startIndex] and
+   * an [endIndex] if set. The return value is inclusive of the start index but not of the end
+   * index. A UTF-16 surrogate pair counts as a single position.
    */
   @JvmName("sliceString")
   public fun slice(
-    value: Expression<String>,
-    start: Expression<Number>,
-    length: Expression<Number>? = null,
+    string: Expression<String>,
+    startIndex: Expression<Number>,
+    endIndex: Expression<Number>? = null,
   ): Expression<String> {
     val args = buildList {
-      add(value)
-      add(start)
-      length?.let { add(it) }
+      add(string)
+      add(startIndex)
+      endIndex?.let { add(it) }
     }
     return callFn("slice", *args.toTypedArray())
   }
 
   /**
-   * Returns an item from an list from a specified start index, or between a start index and an end
-   * index if set. The return value is inclusive of the start index but not of the end index.
+   * Returns an item from a [list] from a specified start index, or between a [startIndex] and an
+   * [endIndex] if set. The return value is inclusive of the start index but not of the end index.
    */
   @JvmName("sliceList")
   public fun <T> slice(
-    value: Expression<List<T>>,
-    start: Expression<Number>,
-    length: Expression<Number>? = null,
+    list: Expression<List<T>>,
+    startIndex: Expression<Number>,
+    endIndex: Expression<Number>? = null,
   ): Expression<T> {
     val args = buildList {
-      add(value)
-      add(start)
-      length?.let { add(it) }
+      add(list)
+      add(startIndex)
+      endIndex?.let { add(it) }
     }
     return callFn("slice", *args.toTypedArray())
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -14,7 +14,7 @@ public interface ExpressionScope {
 
   // basic types: https://maplibre.org/maplibre-style-spec/types/
 
-  //region Literals
+  // region Literals
 
   public fun const(string: String): Expression<String> = Expression.ofString(string)
 
@@ -51,9 +51,9 @@ public interface ExpressionScope {
 
   // expressions: https://maplibre.org/maplibre-style-spec/expressions/
 
-  //endregion
-  //region Variable binding
+  // endregion
 
+  // region Variable binding
   /**
    * Binds expressions to named variables, which can then be referenced in the result expression
    * using [var].
@@ -64,9 +64,9 @@ public interface ExpressionScope {
   /** References variable bound using [let]. */
   public fun <T> `var`(name: String): Expression<T> = callFn("var", const(name))
 
-  //endregion
+  // endregion
 
-  //region Types
+  // region Types
 
   /** Produces a literal list value. */
   public fun <T> literal(values: List<Expression<T>>): Expression<List<T>> =
@@ -79,7 +79,7 @@ public interface ExpressionScope {
   /**
    * Returns a string describing the type of this expression. Either "boolean", "string", "number",
    * "color" or "array".
-   * */
+   */
   public fun Expression<*>.type(): Expression<String> = callFn("typeof", this)
 
   /**
@@ -191,18 +191,19 @@ public interface ExpressionScope {
    * [BackgroundLayer][dev.sargunv.maplibrecompose.compose.layer.BackgroundLayer],
    * [FillLayer][dev.sargunv.maplibrecompose.compose.layer.FillLayer],
    * [FillExtrusionLayer][dev.sargunv.maplibrecompose.compose.layer.FillExtrusionLayer],
-   * [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer])  and as a section in the
+   * [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]) and as a section in the
    * [format] expression.
    *
-   * If set, the image argument will check that the requested image exists in the style
-   * and will return either the resolved image name or `null`, depending on whether or not the image
-   * is currently in the style. This validation process is synchronous and requires the image to
-   * have been added to the style before requesting it in the image argument.
+   * If set, the image argument will check that the requested image exists in the style and will
+   * return either the resolved image name or `null`, depending on whether or not the image is
+   * currently in the style. This validation process is synchronous and requires the image to have
+   * been added to the style before requesting it in the image argument.
    */
   public fun image(value: Expression<String>): Expression<TResolvedImage> = callFn("image", value)
 
   /**
    * Converts this number into a string representation using the provided formatting rules.
+   *
    * @param locale BCP 47 language tag for which locale to use
    * @param currency an ISO 4217 code to use for currency-style formatting
    * @param minFractionDigits minimum fractional digits to include
@@ -273,9 +274,9 @@ public interface ExpressionScope {
   public fun Expression<*>.convertToColor(vararg fallbacks: Expression<*>): Expression<Color> =
     callFn("to-color", this, *fallbacks)
 
-  //endregion
+  // endregion
 
-  //region Lookup
+  // region Lookup
 
   /** Returns the item at [index]. */
   @JvmName("getAtIndex")
@@ -327,8 +328,8 @@ public interface ExpressionScope {
   }
 
   /**
-   * Returns a substring from this string from the [startIndex] (inclusive) to the end of the
-   * string if [endIndex] is not specified or `null`, otherwise to [endIndex] (exclusive).
+   * Returns a substring from this string from the [startIndex] (inclusive) to the end of the string
+   * if [endIndex] is not specified or `null`, otherwise to [endIndex] (exclusive).
    *
    * A UTF-16 surrogate pair counts as a single position.
    */
@@ -364,12 +365,10 @@ public interface ExpressionScope {
    * Returns the value corresponding to the given [key] in the current feature's properties or
    * `null` if it is not present.
    */
-  public fun <T> get(key: Expression<String>): Expression<T> =
-    callFn("get", key)
+  public fun <T> get(key: Expression<String>): Expression<T> = callFn("get", key)
 
   /** Tests for the presence of a property value [key] in the current feature's properties. */
-  public fun has(key: Expression<String>): Expression<Boolean> =
-    callFn("has", key)
+  public fun has(key: Expression<String>): Expression<Boolean> = callFn("has", key)
 
   /** Returns the value corresponding the given [key] or `null` if it is not present in this map. */
   public operator fun <T> Expression<Map<String, *>>.get(key: Expression<String>): Expression<T> =
@@ -391,16 +390,15 @@ public interface ExpressionScope {
   @JvmName("lengthOfList")
   public fun Expression<List<*>>.length(): Expression<Number> = callFn("length", this)
 
-  //endregion
+  // endregion
 
-  //region Decision
+  // region Decision
 
   /**
    * Selects the first output from the given [branches] whose corresponding test condition evaluates
    * to `true`, or the [fallback] value otherwise.
    *
    * Example:
-   *
    * ```
    * case(
    *   (has("color1") and has("color2")) then
@@ -410,6 +408,7 @@ public interface ExpressionScope {
    *   const(Color.Red)
    * )
    * ```
+   *
    * If the feature has both a "color1" and "color2" property, the result is an interpolation
    * between these two colors based on the zoom level. Otherwise, if the feature has a "color"
    * property, that color is returned. If the feature has none of the three, the color red is
@@ -444,7 +443,6 @@ public interface ExpressionScope {
    * will be the [fallback] value.
    *
    * Example:
-   *
    * ```
    * match(
    *   get("building_type"),
@@ -453,6 +451,7 @@ public interface ExpressionScope {
    *   const(Color.Red),
    * )
    * ```
+   *
    * If the feature has a property  "building_type" with the value "residential", cyan is returned.
    * Otherwise, if the value of that property is either "commercial" or "industrial", yellow is
    * returned. If none of that is true, the fallback is returned, i.e. red.
@@ -738,9 +737,9 @@ public interface ExpressionScope {
   public fun within(polygon: Expression<Polygon>): Expression<Boolean> =
     callFn("within", polygon)
 
-  //endregion
+  // endregion
 
-  //region Ramps, Scales, Curves
+  // region Ramps, Scales, Curves
 
   /**
    * Produces discrete, stepped results by evaluating a piecewise-constant function defined by pairs
@@ -753,7 +752,7 @@ public interface ExpressionScope {
    *
    * returns 0 if the zoom is less than 10, 2.5 if the zoom is between 10 and less than 20, 10.5 if
    * the zoom is greater than or equal 20.
-   * */
+   */
   public fun <Output> step(
     input: Expression<Number>,
     fallback: Expression<Output>,
@@ -837,7 +836,8 @@ public interface ExpressionScope {
     vararg stops: Pair<Number, Expression<Color>>,
   ): Expression<Color> = interpolateImpl("interpolate-lab", type, input, *stops)
 
-  /** Interpolates exponentially between the stops. [base] controls the rate at which the output
+  /**
+   * Interpolates exponentially between the stops. [base] controls the rate at which the output
    * increases: higher values make the output increase more towards the high end of the range. With
    * values close to 1 the output increases linearly.
    */
@@ -856,9 +856,9 @@ public interface ExpressionScope {
     y2: Expression<Number>,
   ): Expression<TInterpolationType> = callFn("cubic-bezier", x1, y1, x2, y2)
 
-  //endregion
+  // endregion
 
-  //region Math
+  // region Math
 
   /** Returns mathematical constant ln(2) = natural logarithm of 2. */
   public fun ln2(): Expression<Number> = callFn("ln2")
@@ -973,15 +973,17 @@ public interface ExpressionScope {
   @JvmName("maxDp")
   public fun max(vararg numbers: Expression<Dp>): Expression<Dp> = callFn("max", *numbers)
 
-  /** Rounds [value] to the nearest integer. Halfway values are rounded away from zero.
+  /**
+   * Rounds [value] to the nearest integer. Halfway values are rounded away from zero.
    *
-   *  For example `round(const(-1.5))` evaluates to `-2`.
+   * For example `round(const(-1.5))` evaluates to `-2`.
    */
   public fun round(value: Expression<Number>): Expression<Number> = callFn("round", value)
 
-  /** Rounds [value] to the nearest integer. Halfway values are rounded away from zero.
+  /**
+   * Rounds [value] to the nearest integer. Halfway values are rounded away from zero.
    *
-   *  For example `round(const(-1.5.dp))` evaluates to `-2.dp`.
+   * For example `round(const(-1.5.dp))` evaluates to `-2.dp`.
    */
   @JvmName("roundDp")
   public fun round(value: Expression<Dp>): Expression<Dp> = callFn("round", value)
@@ -1009,13 +1011,13 @@ public interface ExpressionScope {
   public fun distance(geometry: Expression<Geometry>): Expression<Number> =
     callFn("distance", geometry)
 
-  //endregion
+  // endregion
 
-  //region Color
+  // region Color
 
   /**
-   * Returns a four-element list, containing the color's red, green, blue, and alpha components,
-   * in that order.
+   * Returns a four-element list, containing the color's red, green, blue, and alpha components, in
+   * that order.
    */
   public fun Expression<Color>.toRgbaComponents(): Expression<List<Number>> =
     callFn("to-rgba", this)
@@ -1038,9 +1040,9 @@ public interface ExpressionScope {
       callFn("rgb", red, green, blue)
     }
 
-  //endregion
+  // endregion
 
-  //region Feature data
+  // region Feature data
 
   /**
    * Gets the feature properties object. Note that in some cases, it may be more efficient to use
@@ -1063,8 +1065,7 @@ public interface ExpressionScope {
    * provided, features are identified by their `promoteId` property, which may be a number, string,
    * or any primitive data type. Note that [featureState] can only be used with layer properties
    * that support data-driven styling.
-   *
- */
+   */
   // TODO: latest when featureState is supported on native platforms, should document which layer
   //   properties support data-driven styling, i.e. featureState expressions.
   public fun <T> featureState(key: Expression<String>): Expression<T> = callFn("feature-state", key)
@@ -1092,36 +1093,37 @@ public interface ExpressionScope {
    */
   public fun <T> accumulated(key: Expression<String>): Expression<T> = callFn("accumulated", key)
 
-  //endregion
+  // endregion
 
-  //region Zoom
+  // region Zoom
 
   /**
-   * Gets the current zoom level. Note that in layer style properties, [zoom] may only appear as
-   * the input to a top-level [step] or [interpolate] (, [interpolateHcl], [interpolateLab], ...)
+   * Gets the current zoom level. Note that in layer style properties, [zoom] may only appear as the
+   * input to a top-level [step] or [interpolate] (, [interpolateHcl], [interpolateLab], ...)
    * expression.
    */
   public fun zoom(): Expression<Number> = callFn("zoom")
 
-  //endregion
+  // endregion
 
-  //region Heatmap
+  // region Heatmap
 
-  /** Gets the kernel density estimation of a pixel in a heatmap layer, which is a relative measure
-   *  of how many data points are crowded around a particular pixel. Can only be used in the
-   *  expression for the `color` parameter in a
-   *  [HeatmapLayer][dev.sargunv.maplibrecompose.compose.layer.HeatmapLayer].
+  /**
+   * Gets the kernel density estimation of a pixel in a heatmap layer, which is a relative measure
+   * of how many data points are crowded around a particular pixel. Can only be used in the
+   * expression for the `color` parameter in a
+   * [HeatmapLayer][dev.sargunv.maplibrecompose.compose.layer.HeatmapLayer].
    */
   public fun heatmapDensity(): Expression<Number> = callFn("heatmap-density")
 
-  //endregion
+  // endregion
 
-  //region String
+  // region String
 
   /**
-   * Returns true if this string is expected to render legibly. Returns false if this string
-   * contains sections that cannot be rendered without potential loss of meaning (e.g. Indic
-   * scripts that require complex text shaping).
+   * Returns `true` if this string is expected to render legibly. Returns `false` if this string
+   * contains sections that cannot be rendered without potential loss of meaning (e.g. Indic scripts
+   * that require complex text shaping).
    */
   public fun Expression<String>.isScriptSupported(): Expression<Boolean> =
     callFn("is-supported-script", this)
@@ -1150,9 +1152,9 @@ public interface ExpressionScope {
   public fun resolvedLocale(collator: Expression<TCollator>): Expression<String> =
     callFn("resolved-locale", collator)
 
-  //endregion
+  // endregion
 
-  //region Utils
+  // region Utils
 
   @Suppress("UNCHECKED_CAST")
   private fun <Return> callFn(function: String, vararg args: Expression<*>) =
@@ -1172,5 +1174,5 @@ public interface ExpressionScope {
     fold(mutableListOf<Expression<*>>()) { acc, element -> acc.apply { block(element) } }
       .toTypedArray()
 
-  //endregion
+  // endregion
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -656,102 +656,154 @@ public interface ExpressionScope {
 
   //region Math
 
+  /** Returns mathematical constant ln(2) = natural logarithm of 2. */
   public fun ln2(): Expression<Number> = callFn("ln2")
 
+  /** Returns the mathematical constant π */
   public fun pi(): Expression<Number> = callFn("pi")
 
+  /** Returns the mathematical constant e */
   public fun e(): Expression<Number> = callFn("e")
 
+  /** Returns the sum of this number expression with [other]. */
   public operator fun Expression<Number>.plus(other: Expression<Number>): Expression<Number> =
     callFn("+", this, other)
 
+  /** Returns the sum of this dp expression with [other]. */
   @JvmName("plusDp")
   public operator fun Expression<Dp>.plus(other: Expression<Dp>): Expression<Dp> =
     callFn("+", this, other)
 
+  /** Returns the product of this number expression with [other]. */
   public operator fun Expression<Number>.times(other: Expression<Number>): Expression<Number> =
     callFn("*", this, other)
 
+  /** Returns the product of this dp expression with [other]. */
   @JvmName("timesDp")
   public operator fun Expression<Dp>.times(other: Expression<Dp>): Expression<Dp> =
     callFn("*", this, other)
 
+  /** Returns the result of subtracting [other] from this number expression. */
   public operator fun Expression<Number>.minus(other: Expression<Number>): Expression<Number> =
     callFn("-", this, other)
 
+  /** Returns the result of subtracting [other] from this dp expression. */
   @JvmName("minusDp")
   public operator fun Expression<Dp>.minus(other: Expression<Dp>): Expression<Dp> =
     callFn("-", this, other)
 
+  /** Negates this number expression. */
   public operator fun Expression<Number>.unaryMinus(): Expression<Number> = callFn("-", this)
 
+  /** Negates this dp expression. */
   @JvmName("unaryMinusDp")
   public operator fun Expression<Dp>.unaryMinus(): Expression<Dp> = callFn("-", this)
 
-  public operator fun Expression<Number>.div(b: Expression<Number>): Expression<Number> =
-    callFn("/", this, b)
+  /** Returns the result of floating point division of this number expression by [divisor]. */
+  public operator fun Expression<Number>.div(divisor: Expression<Number>): Expression<Number> =
+    callFn("/", this, divisor)
 
+  /** Returns the result of floating point division of this dp expression by [divisor]. */
   @JvmName("divDp")
-  public operator fun Expression<Dp>.div(b: Expression<Dp>): Expression<Dp> = callFn("/", this, b)
+  public operator fun Expression<Dp>.div(divisor: Expression<Dp>): Expression<Dp> =
+    callFn("/", this, divisor)
 
-  public operator fun Expression<Number>.rem(b: Expression<Number>): Expression<Number> =
-    callFn("%", this, b)
+  /** Returns the remainder after integer division of this number expression by [divisor]. */
+  public operator fun Expression<Number>.rem(divisor: Expression<Number>): Expression<Number> =
+    callFn("%", this, divisor)
 
+  /** Returns the remainder after dp division of this number expression by [divisor]. */
   @JvmName("remDp")
-  public operator fun Expression<Dp>.rem(b: Expression<Dp>): Expression<Dp> = callFn("%", this, b)
+  public operator fun Expression<Dp>.rem(divisor: Expression<Dp>): Expression<Dp> =
+    callFn("%", this, divisor)
 
+  /** Returns the result of raising this number expression to the power of [exponent]. */
   public fun Expression<Number>.pow(exponent: Expression<Number>): Expression<Number> =
     callFn("^", this, exponent)
 
+  /** Returns the result of raising this dp expression to the power of [exponent]. */
+  public fun Expression<Dp>.pow(exponent: Expression<Dp>): Expression<Number> =
+    callFn("^", this, exponent)
+
+  /** Returns the square root of [value]. */
   public fun sqrt(value: Expression<Number>): Expression<Number> = callFn("sqrt", value)
 
+  /** Returns the base-ten logarithm of [value]. */
   public fun log10(value: Expression<Number>): Expression<Number> = callFn("log10", value)
 
+  /** Returns the natural logarithm of [value]. */
   public fun ln(value: Expression<Number>): Expression<Number> = callFn("ln", value)
 
+  /** Returns the base-two logarithm of [value]. */
   public fun log2(value: Expression<Number>): Expression<Number> = callFn("log2", value)
 
+  /** Returns the sine of [value]. */
   public fun sin(value: Expression<Number>): Expression<Number> = callFn("sin", value)
 
+  /** Returns the cosine of [value]. */
   public fun cos(value: Expression<Number>): Expression<Number> = callFn("cos", value)
 
+  /** Returns the tangent of [value]. */
   public fun tan(value: Expression<Number>): Expression<Number> = callFn("tan", value)
 
+  /** Returns the arcsine of [value]. */
   public fun asin(value: Expression<Number>): Expression<Number> = callFn("asin", value)
 
+  /** Returns the arccosine of [value]. */
   public fun acos(value: Expression<Number>): Expression<Number> = callFn("acos", value)
 
+  /** Returns the arctangent of [value]. */
   public fun atan(value: Expression<Number>): Expression<Number> = callFn("atan", value)
 
+  /** Returns the smallest of all given [numbers]. */
   public fun min(vararg numbers: Expression<Number>): Expression<Number> = callFn("min", *numbers)
 
+  /** Returns the smallest of all given dp [numbers]. */
   @JvmName("minDp")
   public fun min(vararg numbers: Expression<Dp>): Expression<Dp> = callFn("min", *numbers)
 
+  /** Returns the greatest of all given [numbers]. */
   public fun max(vararg numbers: Expression<Number>): Expression<Number> = callFn("max", *numbers)
 
+  /** Returns the greatest of all given dp [numbers]. */
   @JvmName("maxDp")
   public fun max(vararg numbers: Expression<Dp>): Expression<Dp> = callFn("max", *numbers)
 
+  /** Rounds [value] to the nearest integer. Halfway values are rounded away from zero.
+   *
+   *  For example `round(const(-1.5))` evaluates to `-2`.
+   */
   public fun round(value: Expression<Number>): Expression<Number> = callFn("round", value)
 
+  /** Rounds [value] to the nearest integer. Halfway values are rounded away from zero.
+   *
+   *  For example `round(const(-1.5.dp))` evaluates to `-2.dp`.
+   */
   @JvmName("roundDp")
   public fun round(value: Expression<Dp>): Expression<Dp> = callFn("round", value)
 
+  /** Returns the absolute value of [value], i.e. always a positive value. */
   public fun abs(value: Expression<Number>): Expression<Number> = callFn("abs", value)
 
+  /** Returns the absolute dp value of [value], i.e. always a positive dp value. */
   @JvmName("absDp") public fun abs(value: Expression<Dp>): Expression<Dp> = callFn("abs", value)
 
+  /** Returns the smallest integer that is greater than or equal to [value]. */
   public fun ceil(value: Expression<Number>): Expression<Number> = callFn("ceil", value)
 
+  /** Returns the smallest integer that is greater than or equal to [value]. */
   @JvmName("ceilDp") public fun ceil(value: Expression<Dp>): Expression<Dp> = callFn("ceil", value)
 
+  /** Returns the largest integer that is less than or equal to [value]. */
   public fun floor(value: Expression<Number>): Expression<Number> = callFn("floor", value)
 
+  /** Returns the largest integer that is less than or equal to [value]. */
   @JvmName("floorDp")
   public fun floor(value: Expression<Dp>): Expression<Dp> = callFn("floor", value)
 
-  public fun distance(value: Expression<Geometry>): Expression<Number> = callFn("distance", value)
+  /** Returns the shortest distance in meters between the evaluated feature and [geometry]. */
+  public fun distance(geometry: Expression<Geometry>): Expression<Number> =
+    callFn("distance", geometry)
 
   //endregion
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -68,7 +68,7 @@ public interface ExpressionScope {
 
   //region Types
 
-  /** Produces a literal array value. */
+  /** Produces a literal list value. */
   public fun <T> literal(values: List<Expression<T>>): Expression<List<T>> =
     callFn("literal", Expression.ofList(values))
 
@@ -1074,7 +1074,7 @@ public interface ExpressionScope {
 
   /** Gets the kernel density estimation of a pixel in a heatmap layer, which is a relative measure
    *  of how many data points are crowded around a particular pixel. Can only be used in the
-   *  expression for `color` parameter in a
+   *  expression for the `color` parameter in a
    *  [HeatmapLayer][dev.sargunv.maplibrecompose.compose.layer.HeatmapLayer].
    */
   public fun heatmapDensity(): Expression<Number> = callFn("heatmap-density")

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -793,6 +793,11 @@ public interface ExpressionScope {
 
   //region Zoom
 
+  /**
+   * Gets the current zoom level. Note that in layer style properties, [zoom] may only appear as
+   * the input to a top-level [step] or [interpolate] (, [interpolateHcl], [interpolateLab], ...)
+   * expression.
+   */
   public fun zoom(): Expression<Number> = callFn("zoom")
 
   //endregion

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -258,27 +258,31 @@ public interface ExpressionScope {
   public fun <T> at(index: Expression<Number>, array: Expression<List<T>>): Expression<T> =
     callFn("at", index, array)
 
+  /** Retrieves an item from an array. */
   @JvmName("getAtIndex")
   public operator fun <T> Expression<List<T>>.get(index: Expression<Number>): Expression<T> =
     at(index, this)
 
-  /** Determines whether an item exists in an array. */
+
+  /** Determines whether an [item] exists in [list]. */
   @JvmName("inList")
-  public fun `in`(needle: Expression<*>, haystack: Expression<List<*>>): Expression<Boolean> =
-    callFn("in", needle, haystack)
+  public fun `in`(item: Expression<*>, list: Expression<List<*>>): Expression<Boolean> =
+    callFn("in", item, list)
 
-  /** Determines whether a substring exists in a string. */
-  @JvmName("inString")
-  public fun `in`(needle: Expression<String>, haystack: Expression<String>): Expression<Boolean> =
-    callFn("in", needle, haystack)
-
+  /** Determines whether an [item] exists in this list expression. */
   @JvmName("inListInfix")
-  public infix fun Expression<*>.`in`(other: Expression<List<*>>): Expression<Boolean> =
-    `in`(this, other)
+  public infix fun Expression<*>.`in`(item: Expression<List<*>>): Expression<Boolean> =
+    `in`(this, item)
 
+  /** Determines whether a [substring] exists in a [string]. */
+  @JvmName("inString")
+  public fun `in`(substring: Expression<String>, string: Expression<String>): Expression<Boolean> =
+    callFn("in", substring, string)
+
+  /** Determines whether a [substring] exists in this string expression. */
   @JvmName("inStringInfix")
-  public infix fun Expression<String>.`in`(other: Expression<String>): Expression<Boolean> =
-    `in`(this, other)
+  public infix fun Expression<String>.`in`(substring: Expression<String>): Expression<Boolean> =
+    `in`(this, substring)
 
   /**
    * Returns the first position at which an [substring] can be found in a [string], or -1 if it

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -72,17 +72,23 @@ public interface ExpressionScope {
   public fun <T> literal(values: List<Expression<T>>): Expression<List<T>> =
     callFn("literal", Expression.ofList(values))
 
-  /** Produces a literal object value. */
+  /** Produces a literal map value. */
   public fun <T> literal(values: Map<String, Expression<T>>): Expression<Map<String, T>> =
     callFn("literal", Expression.ofMap(values))
 
   /**
-   * Asserts that the input is a list (optionally with a specific item type and length). If, when
-   * the input expression is evaluated, it is not of the asserted type, then this assertion will
-   * cause the whole expression to be aborted.
+   * Returns a string describing the type of this expression. Either "boolean", "string", "number",
+   * "color" or "array".
+   * */
+  public fun Expression<*>.type(): Expression<String> = callFn("typeof", this)
+
+  /**
+   * Asserts that this is a list (optionally with a specific item [type] and [length]).
+   *
+   * If, when the input expression is evaluated, it is not of the asserted type, then this assertion
+   * will cause the whole expression to be aborted.
    */
-  public fun <T> array(
-    value: Expression<*>,
+  public fun <T> Expression<*>.asList(
     type: Expression<String>? = null,
     length: Expression<Number>? = null,
   ): Expression<List<T>> {
@@ -90,45 +96,44 @@ public interface ExpressionScope {
       type?.let { add(const("array")) }
       length?.let { add(const("array")) }
     }
-    return callFn("array", value, *args.toTypedArray())
+    return callFn("array", this, *args.toTypedArray())
   }
 
-  /** Returns a string describing the type of the given value. */
-  public fun `typeof`(expression: Expression<*>): Expression<String> = callFn("typeof", expression)
+  /**
+   * Asserts that this value is a string.
+   *
+   * In case this expression is not a string, each of the [fallbacks] is evaluated in order until a
+   * string is obtained. If none of the inputs are strings, the expression is an error.
+   */
+  public fun Expression<*>.asString(vararg fallbacks: Expression<*>): Expression<String> =
+    callFn("string", this, *fallbacks)
 
   /**
-   * Asserts that the input value is a string. If multiple values are provided, each one is
-   * evaluated in order until a string is obtained. If none of the inputs are strings, the
-   * expression is an error.
+   * Asserts that this value is a number.
+   *
+   * In case this expression is not a number, each of the [fallbacks] is evaluated in order until a
+   * number is obtained. If none of the inputs are numbers, the expression is an error.
    */
-  public fun string(value: Expression<*>, vararg fallbacks: Expression<*>): Expression<String> =
-    callFn("string", value, *fallbacks)
+  public fun Expression<*>.asNumber(vararg fallbacks: Expression<*>): Expression<Number> =
+    callFn("number", this, *fallbacks)
 
   /**
-   * Asserts that the input value is a number. If multiple values are provided, each one is
-   * evaluated in order until a number is obtained. If none of the inputs are numbers, the
-   * expression is an error.
+   * Asserts that this value is a boolean.
+   *
+   * In case this expression is not a boolean, each of the [fallbacks] is evaluated in order until a
+   * boolean is obtained. If none of the inputs are booleans, the expression is an error.
    */
-  public fun number(value: Expression<*>, vararg fallbacks: Expression<*>): Expression<Number> =
-    callFn("number", value, *fallbacks)
+  public fun Expression<*>.asBoolean(vararg fallbacks: Expression<*>): Expression<Boolean> =
+    callFn("boolean", this, *fallbacks)
 
   /**
-   * Asserts that the input value is a boolean. If multiple values are provided, each one is
-   * evaluated in order until a boolean is obtained. If none of the inputs are booleans, the
-   * expression is an error.
+   * Asserts that this value is a map.
+   *
+   * In case this expression is not a map, each of the [fallbacks] is evaluated in order until a map
+   * is obtained. If none of the inputs are maps, the expression is an error.
    */
-  public fun boolean(value: Expression<*>, vararg fallbacks: Expression<*>): Expression<Boolean> =
-    callFn("boolean", value, *fallbacks)
-
-  /**
-   * Asserts that the input value is an object. If multiple values are provided, each one is
-   * evaluated in order until an object is obtained. If none of the inputs are objects, the
-   * expression is an error.
-   */
-  public fun <T> `object`(
-    value: Expression<*>,
-    vararg fallbacks: Expression<*>,
-  ): Expression<Map<String, T>> = callFn("object", value, *fallbacks)
+  public fun <T> Expression<*>.asMap(vararg fallbacks: Expression<*>): Expression<Map<String, T>> =
+    callFn("object", this, *fallbacks)
 
   /**
    * Returns a collator for use in locale-dependent comparison operations. The [caseSensitive] and

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -854,8 +854,8 @@ public interface ExpressionScope {
   public fun linear(): Expression<TInterpolationType> = callFn("linear")
 
   /**
-   * Interpolates using the cubic bezier curve defined by the given control points between the
-   * pairs of stops.
+   * Interpolates using the cubic bezier curve defined by the given control points between the pairs
+   * of stops.
    */
   public fun cubicBezier(
     x1: Expression<Number>,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -542,18 +542,22 @@ public interface ExpressionScope {
     callFn("coalesce", *values)
 
   /** Returns whether this expression is equal to [other]. */
+  @JvmName("eqBoolean")
   public infix fun Expression<Boolean>.eq(other: Expression<Boolean>): Expression<Boolean> =
     callFn("==", this, other)
 
   /** Returns whether this expression is equal to [other]. */
+  @JvmName("eqString")
   public infix fun Expression<String>.eq(other: Expression<String>): Expression<Boolean> =
     callFn("==", this, other)
 
   /** Returns whether this expression is equal to [other]. */
+  @JvmName("eqNumber")
   public infix fun Expression<Number>.eq(other: Expression<Number>): Expression<Boolean> =
     callFn("==", this, other)
 
   /** Returns whether this expression is equal to [other]. */
+  @JvmName("eqDp")
   public infix fun Expression<Dp>.eq(other: Expression<Dp>): Expression<Boolean> =
     callFn("==", this, other)
 
@@ -569,18 +573,22 @@ public interface ExpressionScope {
   ): Expression<Boolean> = callFn("==", left, right, *buildArgs { collator?.let { add(it) } })
 
   /** Returns whether this expression is not equal to [other]. */
+  @JvmName("neqBoolean")
   public infix fun Expression<Boolean>.neq(other: Expression<Boolean>): Expression<Boolean> =
     callFn("!=", this, other)
 
   /** Returns whether this expression is not equal to [other]. */
+  @JvmName("neqString")
   public infix fun Expression<String>.neq(other: Expression<String>): Expression<Boolean> =
     callFn("!=", this, other)
 
   /** Returns whether this expression is not equal to [other]. */
+  @JvmName("neqNumber")
   public infix fun Expression<Number>.neq(other: Expression<Number>): Expression<Boolean> =
     callFn("!=", this, other)
 
   /** Returns whether this expression is not equal to [other]. */
+  @JvmName("neqDp")
   public infix fun Expression<Dp>.neq(other: Expression<Dp>): Expression<Boolean> =
     callFn("!=", this, other)
 
@@ -747,12 +755,14 @@ public interface ExpressionScope {
    * Returns whether the evaluated feature is fully contained inside the boundary of the given
    * [polygon].
    */
+  @JvmName("withinPolygon")
   public fun within(polygon: Expression<Polygon>): Expression<Boolean> = callFn("within", polygon)
 
   /**
    * Returns whether the evaluated feature is fully contained inside the boundary of the given
    * [polygon].
    */
+  @JvmName("withinMultiPolygon")
   public fun within(polygon: Expression<MultiPolygon>): Expression<Boolean> =
     callFn("within", polygon)
 
@@ -904,6 +914,7 @@ public interface ExpressionScope {
   public fun e(): Expression<Number> = callFn("e")
 
   /** Returns the sum of this number expression with [other]. */
+  @JvmName("plusNumber")
   public operator fun Expression<Number>.plus(other: Expression<Number>): Expression<Number> =
     callFn("+", this, other)
 
@@ -956,10 +967,12 @@ public interface ExpressionScope {
     callFn("%", this, divisor)
 
   /** Returns the result of raising this number expression to the power of [exponent]. */
+  @JvmName("powNumber")
   public fun Expression<Number>.pow(exponent: Expression<Number>): Expression<Number> =
     callFn("^", this, exponent)
 
   /** Returns the result of raising this dp expression to the power of [exponent]. */
+  @JvmName("powDp")
   public fun Expression<Dp>.pow(exponent: Expression<Dp>): Expression<Number> =
     callFn("^", this, exponent)
 
@@ -1175,6 +1188,7 @@ public interface ExpressionScope {
   public fun Expression<String>.lowercase(): Expression<String> = callFn("downcase", this)
 
   /** Concatenates this string expression with [other]. */
+  @JvmName("plusString")
   public operator fun Expression<String>.plus(other: Expression<String>): Expression<String> =
     callFn("concat", this, other)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -1040,8 +1040,26 @@ public interface ExpressionScope {
    */
   public fun <T> properties(): Expression<Map<String, T>> = callFn("properties")
 
-  // not supported on native yet: https://github.com/maplibre/maplibre-native/issues/1698
-  //public fun <T> featureState(key: Expression<String>): Expression<T> = callFn("feature-state", key)
+  /**
+   * **Note: Not supported on native platforms. See
+   * [ticket #1698](https://github.com/maplibre/maplibre-native/issues/1698)**
+   *
+   * Retrieves a property value from the current feature's state. Returns `null` if the requested
+   * property is not present on the feature's state.
+   *
+   * A feature's state is not part of the GeoJSON or vector tile data, and must be set
+   * programmatically on each feature.
+   *
+   * When `source.promoteId` is not provided, features are identified by their `id` attribute, which
+   * must be an integer or a string that can be cast to an integer. When `source.promoteId` is
+   * provided, features are identified by their `promoteId` property, which may be a number, string,
+   * or any primitive data type. Note that [featureState] can only be used with layer properties
+   * that support data-driven styling.
+   *
+ */
+  // TODO: latest when featureState is supported on native platforms, should document which layer
+  //   properties support data-driven styling, i.e. featureState expressions.
+  public fun <T> featureState(key: Expression<String>): Expression<T> = callFn("feature-state", key)
 
   /**
    * Gets the feature's geometry type as a string: "Point", "MultiPoint", "LineString",

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -375,7 +375,7 @@ public interface ExpressionScope {
    *
    * ```
    * case(
-   *   all(has("color1"), has("color2")) then
+   *   (has("color1") and has("color2")) then
    *     interpolate(linear(), zoom(), 1 to get("color1"), 20 to get("color2")),
    *   has("color") then
    *     get("color"),
@@ -420,9 +420,9 @@ public interface ExpressionScope {
    * ```
    * match(
    *   get("building_type"),
-   *   const(Color.Red),
    *   "residential" then const(Color.Cyan),
    *   listOf("commercial", "industrial") then const(Color.Yellow),
+   *   const(Color.Red),
    * )
    * ```
    * If the feature has a property  "building_type" with the value "residential", cyan is returned.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -711,13 +711,21 @@ public interface ExpressionScope {
     collator: Expression<TCollator>? = null,
   ): Expression<Boolean> = callFn("<=", left, right, *buildArgs { collator?.let { add(it) } })
 
-  /** Returns whether both this and [other] expressions are true. */
-  public infix fun Expression<Boolean>.and(other: Expression<Boolean>): Expression<Boolean> =
-    callFn("all", this, other)
+  /** Returns whether all [expressions] are `true`. */
+  public fun all(vararg expressions: Expression<Boolean>): Expression<Boolean> =
+    callFn("all", *expressions)
 
-  /** Returns whether any of this or the [other] expressions are true. */
+  /** Returns whether both this and [other] expressions are `true`. */
+  public infix fun Expression<Boolean>.and(other: Expression<Boolean>): Expression<Boolean> =
+    all(this, other)
+
+  /** Returns whether any [expressions] are `true`. */
+  public fun any(vararg expressions: Expression<Boolean>): Expression<Boolean> =
+    callFn("any", *expressions)
+
+  /** Returns whether any of this or the [other] expressions are `true`. */
   public infix fun Expression<Boolean>.or(other: Expression<Boolean>): Expression<Boolean> =
-    callFn("any", this, other)
+    any(this, other)
 
   /** Negates this expression. */
   @JvmName("notOperator")

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -702,11 +702,9 @@ public interface ExpressionScope {
   public fun any(vararg expressions: Expression<Boolean>): Expression<Boolean> =
     callFn("any", *expressions)
 
-  public fun not(expression: Expression<Boolean>): Expression<Boolean> = callFn("!", expression)
-
   /** Negates this expression. */
   @JvmName("notOperator")
-  public operator fun Expression<Boolean>.not(): Expression<Boolean> = not(this)
+  public operator fun Expression<Boolean>.not(): Expression<Boolean> = callFn("!", this)
 
   /**
    * Returns whether the evaluated feature is fully contained inside the boundary of the given

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -799,6 +799,11 @@ public interface ExpressionScope {
 
   //region Heatmap
 
+  /** Gets the kernel density estimation of a pixel in a heatmap layer, which is a relative measure
+   *  of how many data points are crowded around a particular pixel. Can only be used in the
+   *  expression for `color` parameter in a
+   *  [HeatmapLayer][dev.sargunv.maplibrecompose.compose.layer.HeatmapLayer].
+   */
   public fun heatmapDensity(): Expression<Number> = callFn("heatmap-density")
 
   //endregion

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -1031,7 +1031,8 @@ public interface ExpressionScope {
    */
   public fun <T> properties(): Expression<Map<String, T>> = callFn("properties")
 
-  public fun <T> featureState(key: Expression<String>): Expression<T> = callFn("feature-state", key)
+  // not supported on native yet: https://github.com/maplibre/maplibre-native/issues/1698
+  //public fun <T> featureState(key: Expression<String>): Expression<T> = callFn("feature-state", key)
 
   /**
    * Gets the feature's geometry type as a string: "Point", "MultiPoint", "LineString",

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/LayerPropertyEnum.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/LayerPropertyEnum.kt
@@ -294,7 +294,8 @@ public enum class TextRotationAlignment(override val expr: Expression<String>) :
    * For [SymbolPlacement.Point], this is equivalent to [TextRotationAlignment.Viewport]. Otherwise,
    * aligns glyphs to the x-axis of the viewport and places them along the line.
    *
-   * **Note**: This value not supported on native platforms, yet
+   * **Note**: This value not supported on native platforms, yet, see
+   * [maplibre-native#250](https://github.com/maplibre/maplibre-native/issues/250)**
    */
   ViewportGlyph(const("viewport-glyph")),
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/utils.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/utils.kt
@@ -17,6 +17,11 @@ public sealed interface TResolvedImage
 
 public sealed interface TCollator
 
+/**
+ * @see ExpressionScope.linear
+ * @see ExpressionScope.exponential
+ * @see ExpressionScope.cubicBezier
+ * */
 public sealed interface TInterpolationType
 
 // helpers for default expression values

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/utils.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/utils.kt
@@ -21,7 +21,7 @@ public sealed interface TCollator
  * @see ExpressionScope.linear
  * @see ExpressionScope.exponential
  * @see ExpressionScope.cubicBezier
- * */
+ */
 public sealed interface TInterpolationType
 
 // helpers for default expression values

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
@@ -27,6 +27,10 @@ import dev.sargunv.maplibrecompose.core.expression.Expression
  * @param clusterMaxZoom Max zoom to cluster points on. Clusters are re-evaluated at integer zoom
  *   levels. So, setting the max zoom to 14 means that the clusters will still be displayed on zoom
  *   14.9.
+ * @param clusterMinPoints **Note: Not supported on native platforms, see
+ *   [maplibre-native#261](https://github.com/maplibre/maplibre-native/issues/261)**
+ *
+ *   Minimum number of points necessary to form a cluster if clustering is enabled.
  * @param clusterProperties A map defining custom properties on the generated clusters if clustering
  *   is enabled, aggregating values from clustered points. The keys are the property names, the
  *   values are expressions.
@@ -36,9 +40,6 @@ import dev.sargunv.maplibrecompose.core.expression.Expression
  * @param lineMetrics Whether to calculate line distance metrics. This is required for
  *   [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]s that specify a `gradient`.
  */
-// not supported yet:
-// @param clusterMinPoints Minimum number of points necessary to form a cluster if clustering is
-//   enabled.
 @Immutable
 public data class GeoJsonOptions(
   val minZoom: Int = 0,
@@ -47,8 +48,7 @@ public data class GeoJsonOptions(
   val tolerance: Float = 0.375f,
   val cluster: Boolean = false,
   val clusterRadius: Int = 50,
-  // Not supported yet on Android, iOS: https://github.com/maplibre/maplibre-native/issues/261
-  // val clusterMinPoints: Int = 2,
+  val clusterMinPoints: Int = 2,
   val clusterMaxZoom: Int = maxZoom - 1,
   val clusterProperties: Map<String, ClusterProperty> = emptyMap(),
   val lineMetrics: Boolean = false,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
@@ -33,8 +33,8 @@ import dev.sargunv.maplibrecompose.core.expression.Expression
  *
  *   TODO examples missing, see https://maplibre.org/maplibre-style-spec/sources/#clusterproperties
  *
- * @param lineMetrics Whether to calculate line distance metrics. This is required for line layers
- *   that specify line-gradient values.
+ * @param lineMetrics Whether to calculate line distance metrics. This is required for
+ *   [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]s that specify a `gradient`.
  */
 // not supported yet:
 // @param clusterMinPoints Minimum number of points necessary to form a cluster if clustering is

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonOptions.kt
@@ -31,6 +31,7 @@ import dev.sargunv.maplibrecompose.core.expression.Expression
  *   [maplibre-native#261](https://github.com/maplibre/maplibre-native/issues/261)**
  *
  *   Minimum number of points necessary to form a cluster if clustering is enabled.
+ *
  * @param clusterProperties A map defining custom properties on the generated clusters if clustering
  *   is enabled, aggregating values from clustered points. The keys are the property names, the
  *   values are expressions.


### PR DESCRIPTION
### Changes (and suggestions)

- Added documentation comments

- Added `// regions` (used to group code and collapse/expand these sections in IDEs such as VSCode or IntelliJ)

- Fixed parameter names of `slice`: `length` was wrong, it is `endIndex` ([see source code](https://github.com/maplibre/maplibre-style-spec/blob/main/src/expression/definitions/slice.ts#L22))

- Fixed order of `fallback` parameter for `match` and `case` - it was inconsistent (even though it is consistent in the spec)

- Documentation claims that "==" and "!=" only works for Booleans, Strings, Numbers, so I added overloads for these types instead of for * ([see source code](https://github.com/maplibre/maplibre-style-spec/blob/7604485fc0b66394b62a44fa9d4cd9816d7d8858/src/expression/definitions/comparison.ts#L29-L30))

- Documentation claims that `within` only works for Polygons, so replaced `Geometry` with `Polygon` and `MultiPolygon` in parameter ([see source code](https://github.com/maplibre/maplibre-style-spec/blob/main/src/expression/definitions/within.ts#L11))

- renamed some parameter names to be more "speaking"

- Made many functions that work on another expression into extension functions, analogous to many math functions:
  - `string(e, …)` → `e.asString(…)`
  - `number(e, …)` → `e.asNumber(…)`
  - `boolean(e, …)` → `e.asBoolean(…)`
  - `'object'(e, …)` → `e.asMap(…)` also getting rid of ugly apostrophes
  - `array(e, …)` → `e.asList(…)`
  - `numberFormat(e, ...)` → `e.numberFormat()`
  - `toString(e)` → `e.convertToString()` "convert" is necessary because there's already a `toString` :-/
  - `toNumber(e, …)` → `e.convertToNumber(…)`
  - `toBoolean(e)` → `e.convertToBoolean()`
  - `toColor(e, …)` → `e.convertToString(…)`
  - `i 'in' list` → `list.contains(i)` because those apostrophes around the "in" are quite ugly
  - `indexOf(i, e, …)` → `e.indexOf(i, …)`
  - `slice(list, …)` → `list.slice(…)`
  - `slice(str, …)` → `str.substring(…)` also renamed to be similar to kotlin naming ¯\_(ツ)_/¯
  - `length(e) → `e.length()`
  - `toRgba(e)` → `e.toRgbaComponents()`
  - `isSupportedScript(str)` → `str.isScriptSupported` also switched the two words because before it sounded like str is the script. No, str is a normal string that is *written* in a script
  - `upcase(str)` -> `str.uppercase()` used Kotlin-naming. Also, boy, does it smell like updog in here?
  - `downcase(str)` -> `str.lowercase()` see above
  - 

- Added
  - `string.indexOf(substring, …)` because it was missing
  - `map[i]` / `map.get(i)` it was part of `get(i, …)` before, which didn't make much sense
  - `map.has(i)` it was part of `has(i, …)` before, which didn't make much sense. **NOTE**: I did not rename to kotlin-idiomatic function name `containsKey`. Inconsistent?

- Removed / Replaced
  - `at(i, e)` → there's already `e[i]` / `get(i)`
  - `not(e)` → there's already `!`
  - `sum(…)` → there's `+`
  - `product(…)` → there's `*`
  - `concat(…)` → use `+` operator for strings
  - `rgb(…)` and `rgba(…)` → `rgbColor(…)` because I think it makes sense to write what is being instantiated. (Or alternatively, just `color`, but maybe there will be e.g. a `hsvColor` one day)
