### PR TITLE
docs: add Vulkan setup instructions and update MapLibre version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ tasks.withType<MkdocsTask>().configureEach {
       "release_version" to releaseVersion,
       "snapshot_version" to snapshotVersion,
       "maplibre_ios_version" to libs.versions.maplibre.ios.get(),
+      "maplibre_android_version" to libs.versions.maplibre.android.get(),
     )
   )
 }

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -68,12 +68,40 @@ cocoapods {
 }
 ```
 
+## Set up Vulkan on Android (Optional)
+
+By default, we ship with the standard version of MapLibre for Android, which
+uses the OpenGL backend. If you'd prefer to use the Vulkan backend, you can
+update your build.
+
+First, add the Vulkan build of MapLibre to your version catalog:
+
+```toml title="libs.versions.toml"
+[libraries]
+maplibre-android-vulkan = { module = "org.maplibre.gl:android-sdk-vulkan", version = "{{ gradle.maplibre_android_version }}" }
+```
+
+Then, exclude the standard MapLibre build from your dependency tree, and add the
+Vulkan build to your Android dependencies:
+
+```kotlin title="build.gradle.kts"
+commonMain.dependencies {
+  implementation(libs.maplibre.compose) {
+    exclude(group = "org.maplibre.gl", module = "android-sdk")
+  }
+}
+
+androidMain.dependencies {
+  implementation(libs.maplibre.android.vulkan)
+}
+```
+
 ## Display your first map
 
 In your Composable UI, add a map:
 
 ```kotlin title="App.kt"
--8<- "demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/GettingStarted.kt:app"
+-8 < -"demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/GettingStarted.kt:app"
 ```
 
 When you run your app, you should see the default [demotiles] map. To learn how

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -101,7 +101,7 @@ androidMain.dependencies {
 In your Composable UI, add a map:
 
 ```kotlin title="App.kt"
--8 < -"demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/GettingStarted.kt:app"
+-8<- "demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/GettingStarted.kt:app"
 ```
 
 When you run your app, you should see the default [demotiles] map. To learn how

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidx-composeUi = "1.7.5"
 androidx-navigation = "2.8.0-alpha10"
 kermit = "2.0.5"
 ktor = "3.0.2"
-maplibre-android = "11.6.1"
+maplibre-android = "11.7.0-pre1"
 maplibre-ios = "6.8.1"
 spatialk = "0.3.0"
 


### PR DESCRIPTION
Adds documentation for using MapLibre's Vulkan backend on Android and updates MapLibre Android dependency to 11.7.0-pre1.

