### PR TITLE
build: upgrade MapLibre Android to 11.7.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidx-composeUi = "1.7.5"
 androidx-navigation = "2.8.0-alpha10"
 kermit = "2.0.5"
 ktor = "3.0.2"
-maplibre-android = "11.7.0-pre1"
+maplibre-android = "11.7.0"
 maplibre-ios = "6.8.1"
 spatialk = "0.3.0"
 


### PR DESCRIPTION
Updates MapLibre Android SDK from pre-release version 11.7.0-pre1 to stable release 11.7.0
