### PR TITLE
refactor: make expression type casting more explicit

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -74,7 +74,7 @@ object ClusteredPointsDemo : Demo {
           opacity = const(0.5f),
           radius =
             step(
-              input = get(const("point_count")),
+              input = get(const("point_count")).asNumber(),
               fallback = const(15.dp),
               25 to const(20.dp),
               100 to const(30.dp),
@@ -101,7 +101,7 @@ object ClusteredPointsDemo : Demo {
           id = "clustered-bikes-count",
           source = bikeSource,
           filter = has(const("point_count")),
-          textField = format(get(const("point_count_abbreviated"))),
+          textField = format(get(const("point_count_abbreviated")).asString()),
           textFont = literal(listOf(const("Noto Sans Regular"))),
           textColor = const(MaterialTheme.colorScheme.onBackground),
         )

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/Expression.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/Expression.kt
@@ -10,10 +10,6 @@ private constructor(
   /** The JSON-like value that backs this expression. */
   public val value: Any?
 ) {
-  @PublishedApi
-  @Suppress("UNCHECKED_CAST")
-  internal fun <T : ExpressionValue> cast(): Expression<T> = this as Expression<T>
-
   internal companion object {
     private const val NUM_SMALL_NUMBERS = 512
     private const val SMALL_FLOAT_RESOLUTION = 0.05f

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.core.util.JsOnlyApi
 import kotlin.enums.enumEntries
+import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmName
 import kotlin.time.Duration
 
@@ -82,19 +83,22 @@ public object ExpressionScope {
 
   // region Variable binding
 
+  @JvmInline
+  public value class Variable<@Suppress("unused") T : ExpressionValue>(public val name: String)
+
   /**
    * Binds expressions to named variables, which can then be referenced in the result expression
    * using [useVariable].
    */
   public fun <T : ExpressionValue> withVariable(
-    name: String,
+    variable: Variable<T>,
     value: Expression<*>,
     expression: Expression<T>,
-  ): Expression<T> = callFn("let", const(name), value, expression).cast()
+  ): Expression<T> = callFn("let", const(variable.name), value, expression).cast()
 
   /** References variable bound using [withVariable]. */
-  public fun <T : ExpressionValue> useVariable(name: String): Expression<T> =
-    callFn("var", const(name)).cast()
+  public fun <T : ExpressionValue> useVariable(variable: Variable<T>): Expression<T> =
+    callFn("var", const(variable.name)).cast()
 
   // endregion
 
@@ -244,8 +248,8 @@ public object ExpressionScope {
    * Example:
    * ```
    * format(
-   *   get("name").substring(const(0), const(1)).uppercase() to FormatStyle(textScale = const(1.5)),
-   *   get("name").substring(const(1)) to FormatStyle(),
+   *   get("name").asString().substring(const(0), const(1)).uppercase() to FormatStyle(textScale = const(1.5)),
+   *   get("name").asString().substring(const(1)) to FormatStyle(),
    * )
    * ```
    *
@@ -418,8 +422,8 @@ public object ExpressionScope {
    * found. Accepts an optional [startIndex] from where to begin the search.
    */
   @JvmName("indexOfList")
-  public fun Expression<ListValue<*>>.indexOf(
-    item: Expression<*>,
+  public fun <T : ExpressionValue> Expression<ListValue<T>>.indexOf(
+    item: Expression<T>,
     startIndex: Expression<IntValue>? = null,
   ): Expression<IntValue> {
     val args = buildList {
@@ -468,16 +472,14 @@ public object ExpressionScope {
    * Returns the value corresponding to the given [key] in the current feature's properties or
    * `null` if it is not present.
    */
-  public fun <T : ExpressionValue> get(key: Expression<StringValue>): Expression<T> =
-    callFn("get", key).cast()
+  public fun get(key: Expression<StringValue>): Expression<*> = callFn("get", key)
 
   /** Tests for the presence of a property value [key] in the current feature's properties. */
   public fun has(key: Expression<StringValue>): Expression<BooleanValue> = callFn("has", key).cast()
 
   /** Returns the value corresponding the given [key] or `null` if it is not present in this map. */
-  public operator fun <T : ExpressionValue> Expression<MapValue>.get(
-    key: Expression<StringValue>
-  ): Expression<T> = callFn("get", key, this).cast()
+  public operator fun Expression<MapValue>.get(key: Expression<StringValue>): Expression<*> =
+    callFn("get", key, this)
 
   /** Returns whether the given [key] is in this map. */
   public fun Expression<MapValue>.has(key: Expression<StringValue>): Expression<BooleanValue> =
@@ -511,13 +513,13 @@ public object ExpressionScope {
    *     output = interpolate(
    *       linear(),
    *       zoom(),
-   *       1 to get(const("color1")),
-   *       20 to get(const("color2"))
+   *       1 to get(const("color1")).convertToColor(),
+   *       20 to get(const("color2")).convertToColor()
    *     ),
    *   ),
    *   condition(
    *     test = has(const("color")),
-   *     output = get(const("color")),
+   *     output = get(const("color")).convertToColor(),
    *   ),
    *   fallback = const(Color.Red),
    * )
@@ -564,7 +566,7 @@ public object ExpressionScope {
    * Example:
    * ```
    * switch(
-   *   input = get(const("building_type")),
+   *   input = get(const("building_type")).asString(),
    *   case(
    *     label = "residential",
    *     output = const(Color.Cyan),
@@ -1219,6 +1221,10 @@ public object ExpressionScope {
   // endregion
 
   // region Utils
+
+  @Suppress("UNCHECKED_CAST")
+  /** Casts this expression to the specified type without any runtime check. Use with caution. */
+  public fun <T : ExpressionValue> Expression<*>.cast(): Expression<T> = this as Expression<T>
 
   private fun callFn(function: String, vararg args: Expression<*>): Expression<*> =
     Expression.ofList(

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionScope.kt
@@ -86,19 +86,21 @@ public object ExpressionScope {
   @JvmInline
   public value class Variable<@Suppress("unused") T : ExpressionValue>(public val name: String)
 
-  /**
-   * Binds expressions to named variables, which can then be referenced in the result expression
-   * using [useVariable].
-   */
-  public fun <T : ExpressionValue> withVariable(
-    variable: Variable<T>,
-    value: Expression<*>,
-    expression: Expression<T>,
-  ): Expression<T> = callFn("let", const(variable.name), value, expression).cast()
+  /** Declares a named variable for use in [bind] and [use]. */
+  public fun <T : ExpressionValue> declare(name: String): Variable<T> = Variable(name)
 
-  /** References variable bound using [withVariable]. */
-  public fun <T : ExpressionValue> useVariable(variable: Variable<T>): Expression<T> =
-    callFn("var", const(variable.name)).cast()
+  /**
+   * Binds expressions to variables declared by [declare], which can then be referenced with [use]
+   * in the [expression].
+   */
+  public fun <T : ExpressionValue> Variable<T>.bind(
+    value: Expression<T>,
+    expression: Expression<T>,
+  ): Expression<T> = callFn("let", const(name), value, expression).cast()
+
+  /** References variable bound using [bind]. */
+  public fun <T : ExpressionValue> Variable<T>.use(): Expression<T> =
+    callFn("var", const(name)).cast()
 
   // endregion
 


### PR DESCRIPTION
Improved type safety for expressions by removing implicit auto-casting on get and variables. Variables now have a typed definition, and get returns an unknown expression that must explicitly be cast or validated to narrow the type.