### PR TITLE
feat: add scale bar ornament

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ tasks.withType<MkdocsTask>().configureEach {
       "release_version" to releaseVersion,
       "snapshot_version" to snapshotVersion,
       "maplibre_ios_version" to libs.versions.maplibre.ios.get(),
-      "maplibre_android_version" to libs.versions.maplibre.android.get(),
+      "maplibre_android_version" to libs.versions.maplibre.android.sdk.get(),
     )
   )
 }

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/EdgeToEdgeDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/EdgeToEdgeDemo.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.Modifier
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.rememberCameraState
 import dev.sargunv.maplibrecompose.core.CameraPosition
-import dev.sargunv.maplibrecompose.core.OrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DEFAULT_STYLE
 import dev.sargunv.maplibrecompose.demoapp.Demo
 import dev.sargunv.maplibrecompose.demoapp.DemoAppBar
@@ -29,7 +28,6 @@ object EdgeToEdgeDemo : Demo {
           modifier = Modifier.consumeWindowInsets(padding),
           styleUri = DEFAULT_STYLE,
           cameraState = rememberCameraState(CameraPosition(target = PORTLAND, zoom = 13.0)),
-          ornamentSettings = OrnamentSettings(padding = padding),
         )
       },
     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,8 @@ androidx-composeUi = "1.7.5"
 androidx-navigation = "2.8.0-alpha10"
 kermit = "2.0.5"
 ktor = "3.0.2"
-maplibre-android = "11.7.0"
+maplibre-android-sdk = "11.7.0"
+maplibre-android-plugins = "3.0.2"
 maplibre-ios = "6.8.1"
 spatialk = "0.3.0"
 
@@ -29,7 +30,8 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-maplibre-android = { module = "org.maplibre.gl:android-sdk", version.ref = "maplibre-android" }
+maplibre-android = { module = "org.maplibre.gl:android-sdk", version.ref = "maplibre-android-sdk" }
+maplibre-android-scalebar = { module = "org.maplibre.gl:android-plugin-scalebar-v9", version.ref = "maplibre-android-plugins" }
 spatialk-geojson = { group = "io.github.dellisd.spatialk", name = "geojson", version.ref = "spatialk" }
 
 [plugins]

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -54,7 +54,10 @@ kotlin {
       api(libs.spatialk.geojson)
     }
 
-    androidMain.dependencies { api(libs.maplibre.android) }
+    androidMain.dependencies {
+      api(libs.maplibre.android)
+      implementation(libs.maplibre.android.scalebar)
+    }
 
     commonTest.dependencies {
       implementation(kotlin("test"))

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.viewinterop.AndroidView
 import co.touchlab.kermit.Logger
 import dev.sargunv.maplibrecompose.core.AndroidMap
+import dev.sargunv.maplibrecompose.core.AndroidScaleBar
 import dev.sargunv.maplibrecompose.core.MaplibreMap
 import org.maplibre.android.MapLibre
 import org.maplibre.android.maps.MapView
@@ -64,6 +65,7 @@ internal fun AndroidMapView(
             AndroidMap(
               mapView = mapView,
               map = map,
+              scaleBar = AndroidScaleBar(context, mapView, map),
               layoutDir = layoutDir,
               density = density,
               callbacks = callbacks,

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -49,12 +49,27 @@ import org.maplibre.geojson.Feature as MLNFeature
 internal class AndroidMap(
   private val mapView: MapView,
   private val map: MapLibreMap,
-  internal var layoutDir: LayoutDirection,
-  internal var density: Density,
+  private val scaleBar: AndroidScaleBar,
+  layoutDir: LayoutDirection,
+  density: Density,
   internal var callbacks: MaplibreMap.Callbacks,
   logger: Logger?,
   styleUri: String,
 ) : MaplibreMap {
+
+  internal var layoutDir: LayoutDirection = layoutDir
+    set(value) {
+      field = value
+      scaleBar.layoutDir = value
+      scaleBar.updateLayout()
+    }
+
+  internal var density: Density = density
+    set(value) {
+      field = value
+      scaleBar.density = value
+      scaleBar.updateLayout()
+    }
 
   internal var logger: Logger? = logger
     set(value) {
@@ -202,6 +217,11 @@ internal class AndroidMap(
 
     map.uiSettings.isCompassEnabled = value.isCompassEnabled
     map.uiSettings.compassGravity = value.compassAlignment.toGravity(layoutDir)
+
+    scaleBar.enabled = value.isScaleBarEnabled
+    scaleBar.alignment = value.scaleBarAlignment
+    scaleBar.padding = value.padding
+    scaleBar.updateLayout()
 
     with(density) {
       val left =

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidScaleBar.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidScaleBar.kt
@@ -1,0 +1,64 @@
+package dev.sargunv.maplibrecompose.core
+
+import android.content.Context
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.coerceAtLeast
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.plugins.scalebar.ScaleBarOptions
+import org.maplibre.android.plugins.scalebar.ScaleBarPlugin
+
+internal class AndroidScaleBar(ctx: Context, private val mapView: MapView, map: MapLibreMap) {
+  private val plugin = ScaleBarPlugin(mapView, map)
+  private val scaleBar = plugin.create(ScaleBarOptions(ctx))
+
+  internal var enabled: Boolean
+    get() = scaleBar.isEnabled
+    set(value) {
+      scaleBar.isEnabled = value
+    }
+
+  internal var layoutDir: LayoutDirection = LayoutDirection.Ltr
+  internal var density: Density = Density(1f)
+  internal var alignment: Alignment = Alignment.TopStart
+  internal var padding: PaddingValues = PaddingValues(0.dp)
+
+  internal fun updateLayout() =
+    with(density) {
+      val left = (padding.calculateLeftPadding(layoutDir).coerceAtLeast(0.dp) + 8.dp).roundToPx()
+      val top = (padding.calculateTopPadding().coerceAtLeast(0.dp) + 8.dp).roundToPx()
+      val right = (padding.calculateRightPadding(layoutDir).coerceAtLeast(0.dp) + 8.dp).roundToPx()
+      val bottom = (padding.calculateBottomPadding().coerceAtLeast(0.dp) + 8.dp).roundToPx()
+
+      println("mapView width: ${mapView.width}, height: ${mapView.height}")
+      println("scaleBar width: ${scaleBar.width}, height: ${scaleBar.height}")
+
+      scaleBar.barHeight
+
+      val offset =
+        alignment.align(
+          size =
+            IntSize(
+              width = (mapView.width * scaleBar.ratio).roundToInt(),
+              height =
+                (scaleBar.barHeight +
+                    scaleBar.textSize +
+                    scaleBar.textBarMargin +
+                    2 * scaleBar.borderWidth)
+                  .roundToInt(),
+            ),
+          space =
+            IntSize(width = mapView.width - left - right, height = mapView.height - top - bottom),
+          layoutDirection = layoutDir,
+        )
+
+      scaleBar.marginLeft = (offset.x + left).toFloat()
+      scaleBar.marginTop = (offset.y + top).toFloat()
+    }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/OrnamentSettings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/OrnamentSettings.kt
@@ -8,17 +8,37 @@ import androidx.compose.ui.unit.dp
 /**
  * Defines which additional UI elements are displayed on top of the map.
  *
- * @param padding padding of the ornaments to the edge of the map
- * @param isLogoEnabled whether to display the MapLibre logo
- * @param logoAlignment where to place the MapLibre logo
- * @param isAttributionEnabled whether to display copyright attribution information. If `true`, all
- *   attribution for all sources used is displayed. If there is not enough space to conveniently
- *   display those, a small button in the shape of an ⓘ will be displayed instead. Tapping on it
- *   opens the attribution information in a dialog.
- * @param attributionAlignment where to place the attribution information
+ * @param padding padding of the ornaments to the edge of the map,
+ * @param isLogoEnabled whether to display the MapLibre logo.
+ * @param logoAlignment where to place the MapLibre logo.
+ *
+ * On Android, the four corners are supported.
+ *
+ * On iOS, the four corners, centers along the edges, and the center are supported.
+ *
+ * @param isAttributionEnabled whether to display copyright attribution information.
+ *
+ * If `true`, all attribution for all sources used is displayed. If there is not enough space to
+ * conveniently display those, a small button in the shape of an ⓘ will be displayed instead.
+ * Tapping on it opens the attribution information in a dialog.
+ *
+ * @param attributionAlignment where to place the attribution information.
+ *
+ * On Android, the four corners are supported.
+ *
+ * On iOS, the four corners, centers along the edges, and the center are supported.
+ *
  * @param isCompassEnabled whether to display a compass that shows which direction is north. Tapping
- *   on the compass will reset the camera rotations to zero.
- * @param compassAlignment where to place the compass
+ *   on the compass will reset the camera bearing to zero.
+ * @param compassAlignment where to place the compass (Android: four corners, iOS: nine positions).
+ * @param isScaleBarEnabled whether to display a scale bar that shows the scale of the map.
+ * @param scaleBarAlignment where to place the scale bar.
+ *
+ * On Android, any alignment is supported, but the bar always grows right, so looks best when
+ * aligned to the left.
+ *
+ * On iOS, the four corners, centers along the edges, and the center are supported. The bar grows
+ * according to the alignment, so looks best on either side.
  */
 @Stable
 public data class OrnamentSettings(
@@ -29,9 +49,12 @@ public data class OrnamentSettings(
   val attributionAlignment: Alignment = Alignment.BottomEnd,
   val isCompassEnabled: Boolean = true,
   val compassAlignment: Alignment = Alignment.TopEnd,
+  val isScaleBarEnabled: Boolean = true,
+  val scaleBarAlignment: Alignment = Alignment.TopStart,
 ) {
   public companion object {
     public val AllEnabled: OrnamentSettings = OrnamentSettings()
-    public val AttributionOnly: OrnamentSettings = OrnamentSettings(isCompassEnabled = false)
+    public val AttributionOnly: OrnamentSettings =
+      OrnamentSettings(isCompassEnabled = false, isScaleBarEnabled = false)
   }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -335,17 +335,20 @@ internal class IosMap(
   override fun setOrnamentSettings(value: OrnamentSettings) {
     mapView.logoView.hidden = !value.isLogoEnabled
     mapView.logoViewPosition = value.logoAlignment.toMLNOrnamentPosition(layoutDir)
-    mapView.setLogoViewMargins(calculateMargins(mapView.logoViewPosition, value.padding))
+    mapView.logoViewMargins = calculateMargins(mapView.logoViewPosition, value.padding)
 
     mapView.attributionButton.hidden = !value.isAttributionEnabled
     mapView.attributionButtonPosition = value.attributionAlignment.toMLNOrnamentPosition(layoutDir)
-    mapView.setAttributionButtonMargins(
+    mapView.attributionButtonMargins =
       calculateMargins(mapView.attributionButtonPosition, value.padding)
-    )
 
     mapView.compassView.hidden = !value.isCompassEnabled
     mapView.compassViewPosition = value.compassAlignment.toMLNOrnamentPosition(layoutDir)
-    mapView.setCompassViewMargins(calculateMargins(mapView.compassViewPosition, value.padding))
+    mapView.compassViewMargins = calculateMargins(mapView.compassViewPosition, value.padding)
+
+    mapView.scaleBar.hidden = !value.isScaleBarEnabled
+    mapView.scaleBarPosition = value.scaleBarAlignment.toMLNOrnamentPosition(layoutDir)
+    mapView.scaleBarMargins = calculateMargins(mapView.scaleBarPosition, value.padding)
   }
 
   private fun MLNMapCamera.toCameraPosition(paddingValues: PaddingValues) =


### PR DESCRIPTION
Added scale bar support to MapLibre Compose

This PR adds a scale bar ornament to MapLibre Compose maps. The scale bar can be enabled/disabled and positioned using the `OrnamentSettings` API, similar to other ornaments like the compass and attribution button.

Key changes:
- Added scale bar plugin dependency for Android
- Added `isScaleBarEnabled` and `scaleBarAlignment` properties to `OrnamentSettings`
- Implemented scale bar positioning and padding logic for both Android and iOS platforms

The scale bar grows rightward on Android and adapts to its alignment on iOS. Default position is top-start (top-left).
