### PR TITLE
document MapLibreMap

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/FrameRateDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/FrameRateDemo.kt
@@ -36,7 +36,7 @@ object FrameRateDemo : Demo {
           modifier = Modifier.weight(1f),
           styleUri = DEFAULT_STYLE,
           maximumFps = maximumFps,
-          onFpsChanged = fpsState::recordFps,
+          onFrame = fpsState::recordFps,
         )
 
         Column(modifier = Modifier.padding(16.dp)) {

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/util.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/util.kt
@@ -64,8 +64,8 @@ internal class FrameRateState(private val spinner: String = "◐◓◑◒") {
   private var rollingAverage by mutableStateOf(0.0)
   private var spinnerIndex by mutableStateOf(0)
 
-  fun recordFps(fps: Double) {
-    rollingAverage = (rollingAverage * 0.9) + (fps * 0.1)
+  fun recordFps(framesPerSecond: Double) {
+    rollingAverage = (rollingAverage * 0.9) + (framesPerSecond * 0.1)
     spinnerIndex = (spinnerIndex + 1) % spinner.length
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -23,6 +23,66 @@ import dev.sargunv.maplibrecompose.core.util.PlatformUtils
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.math.roundToInt
 
+/**
+ * Displays a MapLibre based map.
+ *
+ * @param modifier The modifier to be applied to the layout.
+ * @param styleUri The URI of the map style specification JSON to use, see
+ *   [MapLibre Style](https://maplibre.org/maplibre-style-spec/).
+ * @param gestureSettings Defines which user map gestures are enabled.
+ * @param ornamentSettings Defines which additional UI elements are displayed on top of the map.
+ * @param cameraState The camera state specifies what position of the map is rendered, at what
+ *   zoom, at what tilt, etc.
+ * @param onMapClick Invoked when the map is clicked. A click callback can be defined per layer,
+ *   too, see e.g. the `onClick` parameter for
+ *   [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]. However, this callback is
+ *   always called first and can thus prevent subsequent callbacks to be invoked by consuming the
+ *   event.
+ * @param onMapLongClick Invoked when the map is long-clicked. See [onMapClick].
+ * @param onFpsChanged Invoked when the frames per second changed
+ * @param isDebugEnabled Whether the map debug information is shown.
+ * @param maximumFps The maximum frame rate at which the map view is rendered, but it can't excess
+ *   the ability of device hardware.
+ * @param logger kermit logger to use
+ * @param overlay The composable content shown on top of the map.
+ * @param content The map content additional to what is already part of the map as defined in the
+ *   base map style linked in [styleUri].
+ *
+ *   Additional [sources](https://maplibre.org/maplibre-style-spec/sources/) can be added via
+ *   - [rememberGeoJsonSource][dev.sargunv.maplibrecompose.compose.source.rememberGeoJsonSource] (
+ *   see [GeoJsonSource][dev.sargunv.maplibrecompose.core.source.GeoJsonSource]),
+ *   - [rememberVectorSource][dev.sargunv.maplibrecompose.compose.source.rememberVectorSource] (
+ *   see [VectorSource][dev.sargunv.maplibrecompose.core.source.VectorSource]),
+ *   - [rememberRasterSource][dev.sargunv.maplibrecompose.compose.source.rememberRasterSource] (
+ *   see [RasterSource][dev.sargunv.maplibrecompose.core.source.RasterSource])
+ *
+ *   A source that is already defined in the base map style can be referenced via
+ *   [getBaseSource][dev.sargunv.maplibrecompose.compose.source.getBaseSource].
+ *
+ *   The data from a source can then be used in
+ *   [layer](https://maplibre.org/maplibre-style-spec/layers/) definition(s), which define how that
+ *   data is rendered, see
+ *   - [BackgroundLayer][dev.sargunv.maplibrecompose.compose.layer.BackgroundLayer]
+ *   - [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]
+ *   - [FillExtrusionLayer][dev.sargunv.maplibrecompose.compose.layer.FillExtrusionLayer]
+ *   - [FillLayer][dev.sargunv.maplibrecompose.compose.layer.FillLayer]
+ *   - [HeatmapLayer][dev.sargunv.maplibrecompose.compose.layer.HeatmapLayer]
+ *   - [HillshadeLayer][dev.sargunv.maplibrecompose.compose.layer.HillshadeLayer]
+ *   - [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]
+ *   - [RasterLayer][dev.sargunv.maplibrecompose.compose.layer.RasterLayer]
+ *   - [SymbolLayer][dev.sargunv.maplibrecompose.compose.layer.SymbolLayer]
+ *
+ *   By default, the layers defined in this scope are put on top of the layers from the base style,
+ *   in the order they are defined. Alternatively, it is possible to anchor layers at certain
+ *   layers from the base style. This is done, for example, in order to add a layer just below the
+ *   first symbol layer from the base style so that it isn't above labels. See
+ *   - [Anchor.Top][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Top],
+ *   - [Anchor.Bottom][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Bottom],
+ *   - [Anchor.Above][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Above],
+ *   - [Anchor.Below][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Below],
+ *   - [Anchor.Replace][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Replace],
+ *   - [Anchor.At][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.At]
+ * */
 @Composable
 public fun MaplibreMap(
   modifier: Modifier = Modifier,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -31,8 +31,8 @@ import kotlin.math.roundToInt
  *   [MapLibre Style](https://maplibre.org/maplibre-style-spec/).
  * @param gestureSettings Defines which user map gestures are enabled.
  * @param ornamentSettings Defines which additional UI elements are displayed on top of the map.
- * @param cameraState The camera state specifies what position of the map is rendered, at what
- *   zoom, at what tilt, etc.
+ * @param cameraState The camera state specifies what position of the map is rendered, at what zoom,
+ *   at what tilt, etc.
  * @param onMapClick Invoked when the map is clicked. A click callback can be defined per layer,
  *   too, see e.g. the `onClick` parameter for
  *   [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]. However, this callback is
@@ -49,12 +49,12 @@ import kotlin.math.roundToInt
  *   base map style linked in [styleUri].
  *
  *   Additional [sources](https://maplibre.org/maplibre-style-spec/sources/) can be added via
- *   - [rememberGeoJsonSource][dev.sargunv.maplibrecompose.compose.source.rememberGeoJsonSource] (
- *   see [GeoJsonSource][dev.sargunv.maplibrecompose.core.source.GeoJsonSource]),
- *   - [rememberVectorSource][dev.sargunv.maplibrecompose.compose.source.rememberVectorSource] (
- *   see [VectorSource][dev.sargunv.maplibrecompose.core.source.VectorSource]),
- *   - [rememberRasterSource][dev.sargunv.maplibrecompose.compose.source.rememberRasterSource] (
- *   see [RasterSource][dev.sargunv.maplibrecompose.core.source.RasterSource])
+ *     - [rememberGeoJsonSource][dev.sargunv.maplibrecompose.compose.source.rememberGeoJsonSource] (
+ *       see [GeoJsonSource][dev.sargunv.maplibrecompose.core.source.GeoJsonSource]),
+ *     - [rememberVectorSource][dev.sargunv.maplibrecompose.compose.source.rememberVectorSource] (
+ *       see [VectorSource][dev.sargunv.maplibrecompose.core.source.VectorSource]),
+ *     - [rememberRasterSource][dev.sargunv.maplibrecompose.compose.source.rememberRasterSource] (
+ *       see [RasterSource][dev.sargunv.maplibrecompose.core.source.RasterSource])
  *
  *   A source that is already defined in the base map style can be referenced via
  *   [getBaseSource][dev.sargunv.maplibrecompose.compose.source.getBaseSource].
@@ -62,27 +62,27 @@ import kotlin.math.roundToInt
  *   The data from a source can then be used in
  *   [layer](https://maplibre.org/maplibre-style-spec/layers/) definition(s), which define how that
  *   data is rendered, see
- *   - [BackgroundLayer][dev.sargunv.maplibrecompose.compose.layer.BackgroundLayer]
- *   - [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]
- *   - [FillExtrusionLayer][dev.sargunv.maplibrecompose.compose.layer.FillExtrusionLayer]
- *   - [FillLayer][dev.sargunv.maplibrecompose.compose.layer.FillLayer]
- *   - [HeatmapLayer][dev.sargunv.maplibrecompose.compose.layer.HeatmapLayer]
- *   - [HillshadeLayer][dev.sargunv.maplibrecompose.compose.layer.HillshadeLayer]
- *   - [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]
- *   - [RasterLayer][dev.sargunv.maplibrecompose.compose.layer.RasterLayer]
- *   - [SymbolLayer][dev.sargunv.maplibrecompose.compose.layer.SymbolLayer]
+ *     - [BackgroundLayer][dev.sargunv.maplibrecompose.compose.layer.BackgroundLayer]
+ *     - [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]
+ *     - [FillExtrusionLayer][dev.sargunv.maplibrecompose.compose.layer.FillExtrusionLayer]
+ *     - [FillLayer][dev.sargunv.maplibrecompose.compose.layer.FillLayer]
+ *     - [HeatmapLayer][dev.sargunv.maplibrecompose.compose.layer.HeatmapLayer]
+ *     - [HillshadeLayer][dev.sargunv.maplibrecompose.compose.layer.HillshadeLayer]
+ *     - [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]
+ *     - [RasterLayer][dev.sargunv.maplibrecompose.compose.layer.RasterLayer]
+ *     - [SymbolLayer][dev.sargunv.maplibrecompose.compose.layer.SymbolLayer]
  *
  *   By default, the layers defined in this scope are put on top of the layers from the base style,
- *   in the order they are defined. Alternatively, it is possible to anchor layers at certain
- *   layers from the base style. This is done, for example, in order to add a layer just below the
- *   first symbol layer from the base style so that it isn't above labels. See
- *   - [Anchor.Top][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Top],
- *   - [Anchor.Bottom][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Bottom],
- *   - [Anchor.Above][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Above],
- *   - [Anchor.Below][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Below],
- *   - [Anchor.Replace][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Replace],
- *   - [Anchor.At][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.At]
- * */
+ *   in the order they are defined. Alternatively, it is possible to anchor layers at certain layers
+ *   from the base style. This is done, for example, in order to add a layer just below the first
+ *   symbol layer from the base style so that it isn't above labels. See
+ *     - [Anchor.Top][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Top],
+ *     - [Anchor.Bottom][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Bottom],
+ *     - [Anchor.Above][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Above],
+ *     - [Anchor.Below][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Below],
+ *     - [Anchor.Replace][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.Replace],
+ *     - [Anchor.At][dev.sargunv.maplibrecompose.compose.layer.Anchor.Companion.At]
+ */
 @Composable
 public fun MaplibreMap(
   modifier: Modifier = Modifier,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -39,8 +39,7 @@ import kotlin.math.roundToInt
  *   always called first and can thus prevent subsequent callbacks to be invoked by consuming the
  *   event.
  * @param onMapLongClick Invoked when the map is long-clicked. See [onMapClick].
- * @param onFpsChanged Invoked when the frames per second changed. This will usually be called on
- *   every rendered frame.
+ * @param onFrame Invoked on every rendered frame.
  * @param isDebugEnabled Whether the map debug information is shown.
  * @param maximumFps The maximum frame rate at which the map view is rendered, but it can't excess
  *   the ability of device hardware.
@@ -93,7 +92,7 @@ public fun MaplibreMap(
   cameraState: CameraState = rememberCameraState(),
   onMapClick: MapClickHandler = { _, _ -> ClickResult.Pass },
   onMapLongClick: MapClickHandler = { _, _ -> ClickResult.Pass },
-  onFpsChanged: (Double) -> Unit = {},
+  onFrame: (framesPerSecond: Double) -> Unit = {},
   isDebugEnabled: Boolean = false,
   maximumFps: Int = PlatformUtils.getSystemRefreshRate().roundToInt(),
   logger: Logger? = remember { Logger.withTag("maplibre-compose") },
@@ -164,7 +163,7 @@ public fun MaplibreMap(
       styleUri = styleUri,
       update = { map ->
         cameraState.map = map
-        map.onFpsChanged = onFpsChanged
+        map.onFpsChanged = onFrame
         map.isDebugEnabled = isDebugEnabled
         map.setGestureSettings(gestureSettings)
         map.setOrnamentSettings(ornamentSettings)

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -39,7 +39,8 @@ import kotlin.math.roundToInt
  *   always called first and can thus prevent subsequent callbacks to be invoked by consuming the
  *   event.
  * @param onMapLongClick Invoked when the map is long-clicked. See [onMapClick].
- * @param onFpsChanged Invoked when the frames per second changed
+ * @param onFpsChanged Invoked when the frames per second changed. This will usually be called on
+ *   every rendered frame.
  * @param isDebugEnabled Whether the map debug information is shown.
  * @param maximumFps The maximum frame rate at which the map view is rendered, but it can't excess
  *   the ability of device hardware.


### PR DESCRIPTION
This would be the last item of my documentation crusade.

This is draft because there are two open questions:

1. @sargunv sure it should be `MaplibreMap` and not `MapLibreMap`? MapLibre is usually referred to like that

2. the `onFpsChanged` listener/callback is documented in Android to actually be called *on every frame*. I am currently waiting for confirmation that the documentation is indeed correct. If it is correct, this should probably be renamed.