### PR TITLE
feat: add material3 attribution button and dialog

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/app.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/app.kt
@@ -141,7 +141,7 @@ fun DemoAppBar(demo: Demo, navigateUp: () -> Unit, alpha: Float = 1f) {
             Text(text = demo.description)
             Spacer(modifier = Modifier.height(24.dp))
             TextButton(onClick = { showInfo = false }, modifier = Modifier.align(Alignment.End)) {
-              Text("Dismiss")
+              Text("OK")
             }
           }
         }

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/EdgeToEdgeDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/EdgeToEdgeDemo.kt
@@ -10,8 +10,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
+import dev.sargunv.maplibrecompose.compose.controls.AttributionButton
 import dev.sargunv.maplibrecompose.compose.controls.CompassButton
 import dev.sargunv.maplibrecompose.compose.rememberCameraState
+import dev.sargunv.maplibrecompose.compose.rememberStyleState
 import dev.sargunv.maplibrecompose.core.CameraPosition
 import dev.sargunv.maplibrecompose.core.OrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DEFAULT_STYLE
@@ -28,18 +30,28 @@ object EdgeToEdgeDemo : Demo {
 
   @Composable
   override fun Component(navigateUp: () -> Unit) {
-    val camera = rememberCameraState(CameraPosition(target = PORTLAND, zoom = 13.0))
+    val cameraState = rememberCameraState(CameraPosition(target = PORTLAND, zoom = 13.0))
+    val styleState = rememberStyleState()
+
     Scaffold(
       topBar = { DemoAppBar(this, navigateUp, alpha = 0.5f) },
       content = { padding ->
         MaplibreMap(
           modifier = Modifier.consumeWindowInsets(padding),
           styleUri = DEFAULT_STYLE,
-          cameraState = camera,
-          ornamentSettings = OrnamentSettings(padding = padding, isCompassEnabled = false),
+          cameraState = cameraState,
+          styleState = styleState,
+          ornamentSettings =
+            OrnamentSettings(
+              padding = padding,
+              isCompassEnabled = false,
+              isLogoEnabled = false,
+              isAttributionEnabled = false,
+            ),
           overlay = {
             Box(modifier = Modifier.fillMaxSize().padding(padding).padding(8.dp)) {
-              CompassButton(modifier = Modifier.align(Alignment.TopEnd), cameraState = camera)
+              AttributionButton(styleState, modifier = Modifier.align(Alignment.BottomEnd))
+              CompassButton(cameraState, modifier = Modifier.align(Alignment.TopEnd))
             }
           },
         )

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidScaleBar.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidScaleBar.kt
@@ -36,9 +36,6 @@ internal class AndroidScaleBar(ctx: Context, private val mapView: MapView, map: 
       val right = (padding.calculateRightPadding(layoutDir).coerceAtLeast(0.dp) + 8.dp).roundToPx()
       val bottom = (padding.calculateBottomPadding().coerceAtLeast(0.dp) + 8.dp).roundToPx()
 
-      println("mapView width: ${mapView.width}, height: ${mapView.height}")
-      println("scaleBar width: ${scaleBar.width}, height: ${scaleBar.height}")
-
       scaleBar.barHeight
 
       val offset =

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
@@ -1,11 +1,27 @@
 package dev.sargunv.maplibrecompose.core.source
 
+import android.text.Html
+import android.text.style.URLSpan
 import org.maplibre.android.style.sources.Source as MLNSource
 
 public actual sealed class Source {
   internal abstract val impl: MLNSource
   internal actual val id: String
     get() = impl.id
+
+  public actual val attributionLinks: List<AttributionLink>
+    get() {
+      // TODO minSdk 24 to get rid of deprecation warning
+      @Suppress("DEPRECATION") val spanned = Html.fromHtml(impl.attribution)
+
+      val spans = spanned.getSpans(0, spanned.length, URLSpan::class.java)
+      return spans.map {
+        AttributionLink(
+          title = spanned.slice(spanned.getSpanStart(it)..<spanned.getSpanEnd(it)).toString(),
+          url = it.url,
+        )
+      }
+    }
 
   override fun toString(): String = "${this::class.simpleName}(id=\"$id\")"
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -30,6 +30,7 @@ public fun MaplibreMap(
   gestureSettings: GestureSettings = GestureSettings.AllEnabled,
   ornamentSettings: OrnamentSettings = OrnamentSettings.AllEnabled,
   cameraState: CameraState = rememberCameraState(),
+  styleState: StyleState = rememberStyleState(),
   onMapClick: MapClickHandler = { _, _ -> ClickResult.Pass },
   onMapLongClick: MapClickHandler = { _, _ -> ClickResult.Pass },
   onFpsChanged: (Double) -> Unit = {},
@@ -43,9 +44,10 @@ public fun MaplibreMap(
   val styleComposition by rememberStyleComposition(rememberedStyle, logger, content)
 
   val callbacks =
-    remember(cameraState, styleComposition) {
-      object : MaplibreMap.Callbacks {
+    remember(cameraState, styleState, styleComposition) {
+      class Callbacks : MaplibreMap.Callbacks {
         override fun onStyleChanged(map: MaplibreMap, style: Style?) {
+          styleState.attach(style)
           rememberedStyle = style
         }
 
@@ -95,6 +97,8 @@ public fun MaplibreMap(
           }
         }
       }
+
+      Callbacks()
     }
 
   Box(modifier = modifier) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -45,7 +45,7 @@ public fun MaplibreMap(
 
   val callbacks =
     remember(cameraState, styleState, styleComposition) {
-      class Callbacks : MaplibreMap.Callbacks {
+      object : MaplibreMap.Callbacks {
         override fun onStyleChanged(map: MaplibreMap, style: Style?) {
           styleState.attach(style)
           rememberedStyle = style
@@ -97,8 +97,6 @@ public fun MaplibreMap(
           }
         }
       }
-
-      Callbacks()
     }
 
   Box(modifier = modifier) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
@@ -1,0 +1,24 @@
+package dev.sargunv.maplibrecompose.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import dev.sargunv.maplibrecompose.core.Style
+import dev.sargunv.maplibrecompose.core.source.AttributionLink
+
+@Composable
+public fun rememberStyleState(): StyleState {
+  return remember { StyleState() }
+}
+
+public class StyleState internal constructor() {
+  private var style: Style? = null
+
+  internal fun attach(style: Style?) {
+    this.style = style
+  }
+
+  public fun queryAttributionLinks(): List<AttributionLink> {
+    // TODO expose this as State somehow?
+    return style?.getSources()?.flatMap { it.attributionLinks } ?: emptyList()
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/controls/AttributionButton.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/controls/AttributionButton.kt
@@ -1,0 +1,33 @@
+package dev.sargunv.maplibrecompose.compose.controls
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import dev.sargunv.maplibrecompose.compose.StyleState
+
+@Composable
+public fun AttributionButton(
+  styleState: StyleState,
+  modifier: Modifier = Modifier,
+  colors: IconButtonColors = IconButtonDefaults.iconButtonColors(),
+  contentDescription: String = "Attribution",
+) {
+  var showDialog by remember { mutableStateOf(false) }
+
+  IconButton(modifier = modifier, colors = colors, onClick = { showDialog = true }) {
+    Icon(Icons.Outlined.Info, contentDescription = contentDescription)
+  }
+
+  if (showDialog) {
+    AttributionDialog(styleState, onDismiss = { showDialog = false })
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/controls/AttributionDialog.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/controls/AttributionDialog.kt
@@ -1,0 +1,66 @@
+package dev.sargunv.maplibrecompose.compose.controls
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import dev.sargunv.maplibrecompose.compose.StyleState
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+public fun AttributionDialog(
+  styleState: StyleState,
+  onDismiss: () -> Unit,
+  titleText: String = "Data sources",
+  buttonText: String = "OK",
+) {
+  val attributions = remember(styleState) { styleState.queryAttributionLinks() }
+  val uriHandler = LocalUriHandler.current
+
+  BasicAlertDialog(
+    onDismissRequest = onDismiss,
+    content = {
+      Surface(
+        modifier = Modifier.wrapContentWidth().wrapContentHeight().widthIn(min = 280.dp),
+        shape = MaterialTheme.shapes.extraLarge,
+        tonalElevation = AlertDialogDefaults.TonalElevation,
+        contentColor = AlertDialogDefaults.textContentColor,
+      ) {
+        Column(modifier = Modifier.padding(24.dp)) {
+          Text(
+            text = titleText,
+            modifier = Modifier.padding(bottom = 16.dp).semantics { heading() },
+            style = MaterialTheme.typography.headlineSmall,
+          )
+
+          attributions.forEach {
+            TextButton(onClick = { uriHandler.openUri(it.url) }) { Text(text = it.title) }
+          }
+
+          TextButton(
+            onClick = onDismiss,
+            modifier = Modifier.padding(top = 24.dp).align(Alignment.End),
+          ) {
+            Text(text = buttonText, style = MaterialTheme.typography.labelLarge)
+          }
+        }
+      }
+    },
+  )
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/controls/CompassButton.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/controls/CompassButton.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
@@ -29,16 +31,19 @@ public fun CompassButton(
       cameraState.animateTo(cameraState.position.copy(bearing = 0.0, tilt = 0.0))
     }
   },
+  colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
+  contentDescription: String = "Compass",
 ) {
   ElevatedButton(
     modifier = modifier.size(48.dp).aspectRatio(1f),
     onClick = onClick,
     shape = CircleShape,
+    colors = colors,
     contentPadding = PaddingValues(8.dp),
   ) {
     Image(
       painter = painterResource(Res.drawable.compass_needle),
-      contentDescription = "Compass",
+      contentDescription = contentDescription,
       modifier =
         Modifier.fillMaxSize()
           .graphicsLayer(

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/AttributionLink.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/AttributionLink.kt
@@ -1,0 +1,3 @@
+package dev.sargunv.maplibrecompose.core.source
+
+public data class AttributionLink(val title: String, val url: String)

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
@@ -3,4 +3,5 @@ package dev.sargunv.maplibrecompose.core.source
 /** A data source for map data */
 public expect sealed class Source {
   internal val id: String
+  public val attributionLinks: List<AttributionLink>
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/dev/sargunv/maplibrecompose/compose/StyleManagerTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/dev/sargunv/maplibrecompose/compose/StyleManagerTest.kt
@@ -10,7 +10,11 @@ import dev.sargunv.maplibrecompose.core.layer.LineLayer
 import dev.sargunv.maplibrecompose.core.source.GeoJsonOptions
 import dev.sargunv.maplibrecompose.core.source.GeoJsonSource
 import io.github.dellisd.spatialk.geojson.FeatureCollection
-import kotlin.test.*
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalTestApi::class)
 abstract class StyleManagerTest {

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
@@ -1,11 +1,21 @@
 package dev.sargunv.maplibrecompose.core.source
 
+import cocoapods.MapLibre.MLNAttributionInfo
 import cocoapods.MapLibre.MLNSource
+import cocoapods.MapLibre.MLNTileSource
 
 public actual sealed class Source {
   internal abstract val impl: MLNSource
   internal actual val id: String
     get() = impl.identifier
+
+  public actual val attributionLinks: List<AttributionLink>
+    get() =
+      (impl as? MLNTileSource)?.attributionInfos?.mapNotNull {
+        it as MLNAttributionInfo
+        if (it.URL == null) return@mapNotNull null
+        AttributionLink(title = it.title.string(), url = it.URL.toString())
+      } ?: emptyList()
 
   override fun toString(): String = "${this::class.simpleName}(id=\"$id\")"
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import cocoapods.MapLibre.MLNAttributionInfo
 import cocoapods.MapLibre.MLNCoordinateBounds
 import cocoapods.MapLibre.MLNFeatureProtocol
 import cocoapods.MapLibre.MLNOrnamentPosition
@@ -162,4 +163,9 @@ internal fun Alignment.toMLNOrnamentPosition(layoutDir: LayoutDirection): MLNOrn
     IntOffset(1, 1) -> MLNOrnamentPositionBottomRight
     else -> error("Invalid alignment")
   }
+}
+
+internal fun MLNAttributionInfo.toHtmlString(): String {
+  // TODO escape HTML in the title and URL?
+  return if (URL == null) title.string else """<a href="$URL" target="_blank">${title.string}</a>"""
 }


### PR DESCRIPTION
Key changes:
- Created new `AttributionButton` and `AttributionDialog` components
- Added `StyleState` to track and expose style-related information
- Implemented attribution link extraction on Android and iOS

The dialog doesn't extract non-link text from the attribution. This is mirroring the Android SDK's functionality. The iOS SDK's attribution dialog displays non-link text as a button that doesn't work, so I figured it's probably not important.

![CleanShot 2024-12-16 at 19 21 00@2x](https://github.com/user-attachments/assets/f369523f-1b14-45ab-be6e-cfedcb1e5ad5)

