### PR TITLE
chore: update dokka to 2.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ spatialk = "0.3.0"
 
 gradle-android = "8.7.3"
 gradle-compose = "1.7.1"
-gradle-dokka = "2.0.0-Beta"
+gradle-dokka = "2.0.0"
 gradle-jgitver = "0.10.0-rc03"
 gradle-kotlin = "2.1.0"
 gradle-mavenPublish = "0.30.0"


### PR DESCRIPTION
Updates Dokka Gradle plugin from 2.0.0-Beta to 2.0.0 stable release
