### PR TITLE
feat: support text scaling (sp instead of dp)

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -23,6 +23,7 @@ import dev.sargunv.maplibrecompose.core.expression.TextJustify
 import dev.sargunv.maplibrecompose.core.expression.TextPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextRotationAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextTransform
+import dev.sargunv.maplibrecompose.core.expression.TextUnitValue
 import dev.sargunv.maplibrecompose.core.expression.TextWritingMode
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
@@ -170,7 +171,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.textFont(font.toMLNExpression()))
   }
 
-  actual fun setTextSize(size: Expression<DpValue>) {
+  actual fun setTextSize(size: Expression<TextUnitValue>) {
     impl.setProperties(PropertyFactory.textSize(size.toMLNExpression()))
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
 import dev.sargunv.maplibrecompose.core.expression.BooleanValue
@@ -33,6 +34,7 @@ import dev.sargunv.maplibrecompose.core.expression.TextJustify
 import dev.sargunv.maplibrecompose.core.expression.TextPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextRotationAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextTransform
+import dev.sargunv.maplibrecompose.core.expression.TextUnitValue
 import dev.sargunv.maplibrecompose.core.expression.TextWritingMode
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.expression.ZeroPadding
@@ -423,7 +425,7 @@ public fun SymbolLayer(
 
   // text glyph properties
   textFont: Expression<ListValue<StringValue>> = Defaults.FontNames,
-  textSize: Expression<DpValue> = const(16.dp),
+  textSize: Expression<TextUnitValue> = const(16.sp),
   textTransform: Expression<EnumValue<TextTransform>> = const(TextTransform.None),
   textLetterSpacing: Expression<FloatValue> = const(0f),
   textRotationAlignment: Expression<EnumValue<TextRotationAlignment>> =

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.em
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
 import dev.sargunv.maplibrecompose.core.expression.BooleanValue
@@ -56,7 +56,7 @@ import dev.sargunv.maplibrecompose.core.util.JsOnlyApi
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
  *   levels. The
- *   [featureState][dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.featureState]
+ *   [featureState][dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.Feature.state]
  *   expression is not supported in filter expressions.
  * @param visible Whether the layer should be displayed.
  * @param sortKey Sorts features within this layer in ascending order based on this value. Features
@@ -425,7 +425,7 @@ public fun SymbolLayer(
 
   // text glyph properties
   textFont: Expression<ListValue<StringValue>> = Defaults.FontNames,
-  textSize: Expression<TextUnitValue> = const(16.sp),
+  textSize: Expression<TextUnitValue> = const(1.em),
   textTransform: Expression<EnumValue<TextTransform>> = const(TextTransform.None),
   textLetterSpacing: Expression<FloatValue> = const(0f),
   textRotationAlignment: Expression<EnumValue<TextRotationAlignment>> =

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionValue.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionValue.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.TextUnit
 import kotlin.time.Duration
 
 /**
@@ -23,7 +24,7 @@ public sealed interface BooleanValue : ExpressionValue, EquatableValue
  * Represents an [Expression] that resolves to a numeric quantity. Corresponds to numbers in the
  * JSON style spec. Use [ExpressionsDsl.const] to create a literal [ScalarValue].
  *
- * @param U the unit type of the scalar value. For dimensionless quantities, use [Unit].
+ * @param U the unit type of the scalar value. For dimensionless quantities, use [Number].
  */
 public sealed interface ScalarValue<U> :
   ExpressionValue,
@@ -35,19 +36,25 @@ public sealed interface ScalarValue<U> :
 /**
  * Represents an [Expression] that resolves to a dimensionless quantity. See [ExpressionsDsl.const].
  */
-public typealias FloatValue = ScalarValue<Unit>
+public typealias FloatValue = ScalarValue<Number>
 
 /**
  * Represents an [Expression] that resolves to an integer dimensionless quantity. See
  * [ExpressionsDsl.const].
  */
-public sealed interface IntValue : ScalarValue<Unit>
+public sealed interface IntValue : ScalarValue<Number>
 
 /**
  * Represents an [Expression] that resolves to device-independent pixels ([Dp]). See
  * [ExpressionsDsl.const].
  */
 public typealias DpValue = ScalarValue<Dp>
+
+/**
+ * Represents an [Expression] that resolves to a text related dimension ([TextUnit]). See
+ * [ExpressionsDsl.const].
+ */
+public typealias TextUnitValue = ScalarValue<TextUnit>
 
 /**
  * Represents an [Expression] that resolves to an amount of time with millisecond precision
@@ -87,7 +94,7 @@ public sealed interface ListValue<out T : ExpressionValue> : ExpressionValue
 /**
  * Represents an [Expression] that resolves to a list of scalar values.
  *
- * @param U the unit type of the scalar values. For dimensionless quantities, use [Unit].
+ * @param U the unit type of the scalar values. For dimensionless quantities, use [Number].
  */
 public sealed interface VectorValue<U> :
   ListValue<ScalarValue<U>>, InterpolateableValue<VectorValue<U>>
@@ -96,7 +103,7 @@ public sealed interface VectorValue<U> :
  * Represents an [Expression] that resolves to a 2D floating point offset in physical pixels
  * ([Offset]). See [ExpressionsDsl.const].
  */
-public sealed interface OffsetValue : VectorValue<Unit>
+public sealed interface OffsetValue : VectorValue<Number>
 
 /**
  * Represents an [Expression] that resolves to a 2D floating point offset in device-independent

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
@@ -1178,7 +1178,7 @@ public object ExpressionsDsl {
   // region Feature data
 
   /** Object to access feature-related data, see [feature] */
-  public object FeatureScope {
+  public object Feature {
     /**
      * Returns the value corresponding to the given [key] in the current feature's properties or
      * `null` if it is not present.
@@ -1239,7 +1239,7 @@ public object ExpressionsDsl {
   }
 
   /** Accesses to feature-related data */
-  public val feature: FeatureScope = FeatureScope
+  public val feature: Feature = Feature
 
   // endregion
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
@@ -1,10 +1,15 @@
 package dev.sargunv.maplibrecompose.core.expression
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
 import dev.sargunv.maplibrecompose.core.util.JsOnlyApi
 import kotlin.enums.enumEntries
 import kotlin.jvm.JvmInline
@@ -28,6 +33,27 @@ public object ExpressionsDsl {
 
   /** Creates a literal expression for a [Dp] value. */
   public fun const(dp: Dp): Expression<DpValue> = Expression.ofFloat(dp.value).cast()
+
+  /**
+   * Creates a literal expression for a specified [TextUnit] value. If [textUnit] is in `em`, it is
+   * considered relative to `16.sp`.
+   */
+  public fun const(textUnit: TextUnit, fontScale: Float): Expression<TextUnitValue> =
+    when (textUnit.type) {
+      TextUnitType.Sp -> const(textUnit.value * fontScale).cast()
+      TextUnitType.Em -> const(textUnit.value * fontScale * 16f).cast()
+      else -> error("Unsupported TextUnit type: ${textUnit.type}")
+    }
+
+  /**
+   * Creates a literal expression for a specified [TextUnit] value. If [textUnit] is in `em`, it is
+   * considered relative to `16.sp` (the default symbol layer text size).
+   */
+  @Composable
+  public fun const(
+    textUnit: TextUnit,
+    density: Density = LocalDensity.current,
+  ): Expression<TextUnitValue> = const(textUnit, density.fontScale)
 
   /**
    * Creates a literal expression for a [Duration] value.

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -23,6 +23,7 @@ import dev.sargunv.maplibrecompose.core.expression.TextJustify
 import dev.sargunv.maplibrecompose.core.expression.TextPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextRotationAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextTransform
+import dev.sargunv.maplibrecompose.core.expression.TextUnitValue
 import dev.sargunv.maplibrecompose.core.expression.TextWritingMode
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
@@ -95,7 +96,7 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setTextFont(font: Expression<ListValue<StringValue>>)
 
-  fun setTextSize(size: Expression<DpValue>)
+  fun setTextSize(size: Expression<TextUnitValue>)
 
   fun setTextMaxWidth(maxWidth: Expression<FloatValue>)
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -24,6 +24,7 @@ import dev.sargunv.maplibrecompose.core.expression.TextJustify
 import dev.sargunv.maplibrecompose.core.expression.TextPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextRotationAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextTransform
+import dev.sargunv.maplibrecompose.core.expression.TextUnitValue
 import dev.sargunv.maplibrecompose.core.expression.TextWritingMode
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
@@ -175,7 +176,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.textFontNames = font.toNSExpression()
   }
 
-  actual fun setTextSize(size: Expression<DpValue>) {
+  actual fun setTextSize(size: Expression<TextUnitValue>) {
     impl.textFontSize = size.toNSExpression()
   }
 


### PR DESCRIPTION
Add new `ScalarValue<TextUnit>` and `const` functions for the unit. There's a `@Composable` one to provide font scaling automatically. If the provided text unit is in ems, it's considered relative to 16sp, the default font size of the map.