### PR TITLE
refactor: tweak font scaling api

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/RasterLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/RasterLayer.kt
@@ -1,9 +1,9 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import dev.sargunv.maplibrecompose.core.expression.DurationValue
 import dev.sargunv.maplibrecompose.core.expression.EnumValue
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.FloatValue
+import dev.sargunv.maplibrecompose.core.expression.MillisecondsValue
 import dev.sargunv.maplibrecompose.core.expression.RasterResampling
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.util.toMLNExpression
@@ -42,7 +42,7 @@ internal actual class RasterLayer actual constructor(id: String, actual val sour
     impl.setProperties(PropertyFactory.rasterResampling(resampling.toMLNExpression()))
   }
 
-  actual fun setRasterFadeDuration(fadeDuration: Expression<DurationValue>) {
+  actual fun setRasterFadeDuration(fadeDuration: Expression<MillisecondsValue>) {
     impl.setProperties(PropertyFactory.rasterFadeDuration(fadeDuration.toMLNExpression()))
   }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -23,7 +23,6 @@ import dev.sargunv.maplibrecompose.core.expression.TextJustify
 import dev.sargunv.maplibrecompose.core.expression.TextPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextRotationAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextTransform
-import dev.sargunv.maplibrecompose.core.expression.TextUnitValue
 import dev.sargunv.maplibrecompose.core.expression.TextWritingMode
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
@@ -171,7 +170,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.textFont(font.toMLNExpression()))
   }
 
-  actual fun setTextSize(size: Expression<TextUnitValue>) {
+  actual fun setTextSize(size: Expression<DpValue>) {
     impl.setProperties(PropertyFactory.textSize(size.toMLNExpression()))
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/RasterLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/RasterLayer.kt
@@ -2,11 +2,11 @@ package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
-import dev.sargunv.maplibrecompose.core.expression.DurationValue
 import dev.sargunv.maplibrecompose.core.expression.EnumValue
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.const
 import dev.sargunv.maplibrecompose.core.expression.FloatValue
+import dev.sargunv.maplibrecompose.core.expression.MillisecondsValue
 import dev.sargunv.maplibrecompose.core.expression.RasterResampling
 import dev.sargunv.maplibrecompose.core.layer.RasterLayer
 import dev.sargunv.maplibrecompose.core.source.Source
@@ -51,7 +51,7 @@ public fun RasterLayer(
   saturation: Expression<FloatValue> = const(0f),
   contrast: Expression<FloatValue> = const(0f),
   resampling: Expression<EnumValue<RasterResampling>> = const(RasterResampling.Linear),
-  fadeDuration: Expression<DurationValue> = const(300.milliseconds),
+  fadeDuration: Expression<MillisecondsValue> = const(300.milliseconds),
 ) {
   LayerNode(
     factory = { RasterLayer(id = id, source = source) },

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -464,6 +464,8 @@ public fun SymbolLayer(
   onClick: FeaturesClickHandler? = null,
   onLongClick: FeaturesClickHandler? = null,
 ) {
+  // used for scaling textSize from sp (api) to dp (core)
+  // TODO needs changes after https://github.com/maplibre/maplibre-native/issues/3057
   val textScale = LocalDensity.current.fontScale
   LayerNode(
     factory = { SymbolLayer(id = id, source = source) },

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -3,6 +3,7 @@ package dev.sargunv.maplibrecompose.compose.layer
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
@@ -15,8 +16,10 @@ import dev.sargunv.maplibrecompose.core.expression.DpOffsetValue
 import dev.sargunv.maplibrecompose.core.expression.DpValue
 import dev.sargunv.maplibrecompose.core.expression.EnumValue
 import dev.sargunv.maplibrecompose.core.expression.Expression
+import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.cast
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.const
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.nil
+import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.times
 import dev.sargunv.maplibrecompose.core.expression.FloatValue
 import dev.sargunv.maplibrecompose.core.expression.FormattedValue
 import dev.sargunv.maplibrecompose.core.expression.IconPitchAlignment
@@ -26,6 +29,7 @@ import dev.sargunv.maplibrecompose.core.expression.ImageValue
 import dev.sargunv.maplibrecompose.core.expression.ListValue
 import dev.sargunv.maplibrecompose.core.expression.OffsetValue
 import dev.sargunv.maplibrecompose.core.expression.PaddingValue
+import dev.sargunv.maplibrecompose.core.expression.SpValue
 import dev.sargunv.maplibrecompose.core.expression.StringValue
 import dev.sargunv.maplibrecompose.core.expression.SymbolAnchor
 import dev.sargunv.maplibrecompose.core.expression.SymbolPlacement
@@ -34,7 +38,6 @@ import dev.sargunv.maplibrecompose.core.expression.TextJustify
 import dev.sargunv.maplibrecompose.core.expression.TextPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextRotationAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextTransform
-import dev.sargunv.maplibrecompose.core.expression.TextUnitValue
 import dev.sargunv.maplibrecompose.core.expression.TextWritingMode
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.expression.ZeroPadding
@@ -425,7 +428,7 @@ public fun SymbolLayer(
 
   // text glyph properties
   textFont: Expression<ListValue<StringValue>> = Defaults.FontNames,
-  textSize: Expression<TextUnitValue> = const(1.em),
+  textSize: Expression<SpValue> = const(1.em),
   textTransform: Expression<EnumValue<TextTransform>> = const(TextTransform.None),
   textLetterSpacing: Expression<FloatValue> = const(0f),
   textRotationAlignment: Expression<EnumValue<TextRotationAlignment>> =
@@ -461,6 +464,7 @@ public fun SymbolLayer(
   onClick: FeaturesClickHandler? = null,
   onLongClick: FeaturesClickHandler? = null,
 ) {
+  val textScale = LocalDensity.current.fontScale
   LayerNode(
     factory = { SymbolLayer(id = id, source = source) },
     update = {
@@ -502,7 +506,8 @@ public fun SymbolLayer(
       set(textRotationAlignment) { layer.setTextRotationAlignment(it) }
       set(textField) { layer.setTextField(it) }
       set(textFont) { layer.setTextFont(it) }
-      set(textSize) { layer.setTextSize(it) }
+      set(textSize) { layer.setTextSize((it * const(textScale)).cast()) }
+      set(textScale) { layer.setTextSize((textSize * const(it)).cast()) }
       set(textMaxWidth) { layer.setTextMaxWidth(it) }
       set(textLineHeight) { layer.setTextLineHeight(it) }
       set(textLetterSpacing) { layer.setTextLetterSpacing(it) }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionValue.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionValue.kt
@@ -51,16 +51,16 @@ public sealed interface IntValue : ScalarValue<Number>
 public typealias DpValue = ScalarValue<Dp>
 
 /**
- * Represents an [Expression] that resolves to a text related dimension ([TextUnit]). See
+ * Represents an [Expression] that resolves to scalable pixels ([TextUnit] in SP). See
  * [ExpressionsDsl.const].
  */
-public typealias TextUnitValue = ScalarValue<TextUnit>
+public typealias SpValue = ScalarValue<TextUnit>
 
 /**
  * Represents an [Expression] that resolves to an amount of time with millisecond precision
  * ([Duration]). See [ExpressionsDsl.const].
  */
-public typealias DurationValue = ScalarValue<Duration>
+public typealias MillisecondsValue = ScalarValue<Duration>
 
 /** Represents an [Expression] that resolves to a string value. See [ExpressionsDsl.const]. */
 public sealed interface StringValue :

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.TextUnit
@@ -36,31 +35,32 @@ public object ExpressionsDsl {
 
   /**
    * Creates a literal expression for a specified [TextUnit] value. If [textUnit] is in `em`, it is
-   * considered relative to `16.sp`.
+   * converted to SP relative to [STANDARD_MAP_TEXT_SIZE_SP].
    */
-  public fun const(textUnit: TextUnit, fontScale: Float): Expression<TextUnitValue> =
+  public fun const(textUnit: TextUnit, fontScale: Float): Expression<SpValue> =
     when (textUnit.type) {
       TextUnitType.Sp -> const(textUnit.value * fontScale).cast()
-      TextUnitType.Em -> const(textUnit.value * fontScale * 16f).cast()
+      TextUnitType.Em -> const(textUnit.value * fontScale * STANDARD_MAP_TEXT_SIZE_SP).cast()
       else -> error("Unsupported TextUnit type: ${textUnit.type}")
     }
 
   /**
    * Creates a literal expression for a specified [TextUnit] value. If [textUnit] is in `em`, it is
-   * considered relative to `16.sp` (the default symbol layer text size).
+   * considered relative to [STANDARD_MAP_TEXT_SIZE_SP].
    */
   @Composable
-  public fun const(
-    textUnit: TextUnit,
-    density: Density = LocalDensity.current,
-  ): Expression<TextUnitValue> = const(textUnit, density.fontScale)
+  public fun const(textUnit: TextUnit): Expression<SpValue> =
+    const(textUnit, LocalDensity.current.fontScale)
+
+  /** The standard text size in SP used for converting `em` values to `sp`. */
+  public const val STANDARD_MAP_TEXT_SIZE_SP: Float = 16f
 
   /**
    * Creates a literal expression for a [Duration] value.
    *
    * The duration will be rounded to the nearest whole milliseconds.
    */
-  public fun const(duration: Duration): Expression<DurationValue> =
+  public fun const(duration: Duration): Expression<MillisecondsValue> =
     Expression.ofInt(duration.inWholeMilliseconds.toInt()).cast()
 
   /** Creates a literal expression for a [Boolean] value. */
@@ -97,12 +97,23 @@ public object ExpressionsDsl {
   public val Expression<FloatValue>.dp: Expression<DpValue>
     get() = this.cast()
 
-  /** Converts a numeric [Expression] in milliseconds to a [DurationValue] expression. */
-  public val Expression<FloatValue>.milliseconds: Expression<DurationValue>
+  /** Converts a numeric [Expression] to an [SpValue] expression. */
+  public val Expression<FloatValue>.sp: Expression<SpValue>
     get() = this.cast()
 
-  /** Converts a numeric [Expression] in seconds to a [DurationValue] expression. */
-  public val Expression<FloatValue>.seconds: Expression<DurationValue>
+  /**
+   * Converts a numeric [Expression] to an [SpValue] expression relative to
+   * [STANDARD_MAP_TEXT_SIZE_SP].
+   */
+  public val Expression<FloatValue>.em: Expression<SpValue>
+    get() = (this * const(STANDARD_MAP_TEXT_SIZE_SP)).cast()
+
+  /** Converts a numeric [Expression] in milliseconds to a [MillisecondsValue] expression. */
+  public val Expression<FloatValue>.milliseconds: Expression<MillisecondsValue>
+    get() = this.cast()
+
+  /** Converts a numeric [Expression] in seconds to a [MillisecondsValue] expression. */
+  public val Expression<FloatValue>.seconds: Expression<MillisecondsValue>
     get() = (this * const(1000)).cast()
 
   // endregion

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
@@ -1,10 +1,8 @@
 package dev.sargunv.maplibrecompose.core.expression
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.TextUnit
@@ -37,20 +35,12 @@ public object ExpressionsDsl {
    * Creates a literal expression for a specified [TextUnit] value. If [textUnit] is in `em`, it is
    * converted to SP relative to [STANDARD_MAP_TEXT_SIZE_SP].
    */
-  public fun const(textUnit: TextUnit, fontScale: Float): Expression<SpValue> =
+  public fun const(textUnit: TextUnit): Expression<SpValue> =
     when (textUnit.type) {
-      TextUnitType.Sp -> const(textUnit.value * fontScale).cast()
-      TextUnitType.Em -> const(textUnit.value * fontScale * STANDARD_MAP_TEXT_SIZE_SP).cast()
+      TextUnitType.Sp -> const(textUnit.value).cast()
+      TextUnitType.Em -> const(textUnit.value * STANDARD_MAP_TEXT_SIZE_SP).cast()
       else -> error("Unsupported TextUnit type: ${textUnit.type}")
     }
-
-  /**
-   * Creates a literal expression for a specified [TextUnit] value. If [textUnit] is in `em`, it is
-   * considered relative to [STANDARD_MAP_TEXT_SIZE_SP].
-   */
-  @Composable
-  public fun const(textUnit: TextUnit): Expression<SpValue> =
-    const(textUnit, LocalDensity.current.fontScale)
 
   /** The standard text size in SP used for converting `em` values to `sp`. */
   public const val STANDARD_MAP_TEXT_SIZE_SP: Float = 16f

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
@@ -1,7 +1,6 @@
 package dev.sargunv.maplibrecompose.core.expression
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
@@ -90,7 +89,7 @@ public object ExpressionsDsl {
 
   /** Converts a numeric [Expression] to an [SpValue] expression. */
   public val Expression<FloatValue>.sp: Expression<SpValue>
-    get() = this.cast().run { LocalTextStyle }
+    get() = this.cast()
 
   /**
    * Converts a numeric [Expression] to an [SpValue] expression relative to

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionsDsl.kt
@@ -1,6 +1,7 @@
 package dev.sargunv.maplibrecompose.core.expression
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
@@ -89,7 +90,7 @@ public object ExpressionsDsl {
 
   /** Converts a numeric [Expression] to an [SpValue] expression. */
   public val Expression<FloatValue>.sp: Expression<SpValue>
-    get() = this.cast()
+    get() = this.cast().run { LocalTextStyle }
 
   /**
    * Converts a numeric [Expression] to an [SpValue] expression relative to

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/RasterLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/RasterLayer.kt
@@ -1,9 +1,9 @@
 package dev.sargunv.maplibrecompose.core.layer
 
-import dev.sargunv.maplibrecompose.core.expression.DurationValue
 import dev.sargunv.maplibrecompose.core.expression.EnumValue
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.FloatValue
+import dev.sargunv.maplibrecompose.core.expression.MillisecondsValue
 import dev.sargunv.maplibrecompose.core.expression.RasterResampling
 import dev.sargunv.maplibrecompose.core.source.Source
 
@@ -24,5 +24,5 @@ internal expect class RasterLayer(id: String, source: Source) : Layer {
 
   fun setRasterResampling(resampling: Expression<EnumValue<RasterResampling>>)
 
-  fun setRasterFadeDuration(fadeDuration: Expression<DurationValue>)
+  fun setRasterFadeDuration(fadeDuration: Expression<MillisecondsValue>)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -23,7 +23,6 @@ import dev.sargunv.maplibrecompose.core.expression.TextJustify
 import dev.sargunv.maplibrecompose.core.expression.TextPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextRotationAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextTransform
-import dev.sargunv.maplibrecompose.core.expression.TextUnitValue
 import dev.sargunv.maplibrecompose.core.expression.TextWritingMode
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
@@ -96,7 +95,7 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setTextFont(font: Expression<ListValue<StringValue>>)
 
-  fun setTextSize(size: Expression<TextUnitValue>)
+  fun setTextSize(size: Expression<DpValue>)
 
   fun setTextMaxWidth(maxWidth: Expression<FloatValue>)
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/RasterLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/RasterLayer.kt
@@ -1,10 +1,10 @@
 package dev.sargunv.maplibrecompose.core.layer
 
 import cocoapods.MapLibre.MLNRasterStyleLayer
-import dev.sargunv.maplibrecompose.core.expression.DurationValue
 import dev.sargunv.maplibrecompose.core.expression.EnumValue
 import dev.sargunv.maplibrecompose.core.expression.Expression
 import dev.sargunv.maplibrecompose.core.expression.FloatValue
+import dev.sargunv.maplibrecompose.core.expression.MillisecondsValue
 import dev.sargunv.maplibrecompose.core.expression.RasterResampling
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.util.toNSExpression
@@ -42,7 +42,7 @@ internal actual class RasterLayer actual constructor(id: String, actual val sour
     impl.rasterResamplingMode = resampling.toNSExpression()
   }
 
-  actual fun setRasterFadeDuration(fadeDuration: Expression<DurationValue>) {
+  actual fun setRasterFadeDuration(fadeDuration: Expression<MillisecondsValue>) {
     impl.rasterFadeDuration = fadeDuration.toNSExpression()
   }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -24,7 +24,6 @@ import dev.sargunv.maplibrecompose.core.expression.TextJustify
 import dev.sargunv.maplibrecompose.core.expression.TextPitchAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextRotationAlignment
 import dev.sargunv.maplibrecompose.core.expression.TextTransform
-import dev.sargunv.maplibrecompose.core.expression.TextUnitValue
 import dev.sargunv.maplibrecompose.core.expression.TextWritingMode
 import dev.sargunv.maplibrecompose.core.expression.TranslateAnchor
 import dev.sargunv.maplibrecompose.core.source.Source
@@ -176,7 +175,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.textFontNames = font.toNSExpression()
   }
 
-  actual fun setTextSize(size: Expression<TextUnitValue>) {
+  actual fun setTextSize(size: Expression<DpValue>) {
     impl.textFontSize = size.toNSExpression()
   }
 


### PR DESCRIPTION
tweaking things from https://github.com/sargunv/maplibre-compose/pull/134

* update scalar expression naming to SpValue and MillisecondsValue to better reflect the actual internal representation
* update SymbolLayer in core to accept a DpValue expression, matching what the platform SDKs expect
* update the expression DSL to simplify the TextUnit to Expression<SpValue> conversion
  * internal representation of an SpValue is now in sp instead of dp
  * and conversion to Expression<DpValue> is done at the boundary between the SymbolLayer composable and the core wrapper
* link the upstream issue for font scaling