### PR TITLE
fix: disallow expressions inside literal lists/maps

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -24,7 +24,6 @@ import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.asString
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.const
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.feature
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.format
-import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.literal
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.not
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.step
 import dev.sargunv.maplibrecompose.core.source.GeoJsonOptions
@@ -34,7 +33,6 @@ import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.generated.Res
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.FeatureCollection
-import io.github.dellisd.spatialk.geojson.Geometry
 import io.github.dellisd.spatialk.geojson.Point
 import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.launch
@@ -95,7 +93,7 @@ object ClusteredPointsDemo : Demo {
                 5000 to const(60.dp),
               ),
             onClick = { features ->
-              features.firstOrNull<Feature>()?.geometry?.let<Geometry, ClickResult> {
+              features.firstOrNull()?.geometry?.let {
                 coroutineScope.launch {
                   cameraState.animateTo(
                     cameraState.position.copy(
@@ -114,7 +112,7 @@ object ClusteredPointsDemo : Demo {
             source = bikeSource,
             filter = feature.has(const("point_count")),
             textField = format(feature.get(const("point_count_abbreviated")).asString()),
-            textFont = literal(listOf(const("Noto Sans Regular"))),
+            textFont = const(listOf("Noto Sans Regular")),
             textColor = const(MaterialTheme.colorScheme.onBackground),
           )
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/Expression.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/Expression.kt
@@ -58,8 +58,8 @@ private constructor(
     fun <T : ExpressionValue> ofMap(map: Map<String, Expression<T>>): Expression<MapValue<T>> =
       if (map.isEmpty()) ofEmptyMap else Expression(map.mapValues { it.value.value })
 
-    fun <T : ExpressionValue> ofList(list: List<Expression<T>>): Expression<ListValue<T>> =
-      if (list.isEmpty()) ofEmptyList else Expression(list.map { it.value })
+    fun ofList(list: List<*>): Expression<ListValue<*>> =
+      if (list.isEmpty()) ofEmptyList else Expression(list)
 
     fun ofOffset(offset: Offset) = if (offset == Offset.Zero) ofZeroOffset else Expression(offset)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionValue.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/ExpressionValue.kt
@@ -115,7 +115,7 @@ public sealed interface DpOffsetValue : VectorValue<Dp>
 
 /**
  * Represents an [Expression] that resolves to a 2D floating point offset in scalable pixels or em
- * ([TextUnit]). See [ExpressionsDsl.textOffset].
+ * ([TextUnit]). See (TODO).
  */
 public sealed interface TextOffsetValue : VectorValue<TextUnit>
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/utils.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/expression/utils.kt
@@ -7,7 +7,6 @@ import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.const
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.heatmapDensity
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.interpolate
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.linear
-import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.literal
 
 // helpers for default expression values
 
@@ -27,5 +26,5 @@ public object Defaults {
     )
 
   public val FontNames: Expression<ListValue<StringValue>> =
-    literal(listOf(const("Open Sans Regular"), const("Arial Unicode MS Regular")))
+    const(listOf("Open Sans Regular", "Arial Unicode MS Regular"))
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -11,7 +11,6 @@ import cocoapods.MapLibre.MLNShapeSourceOptionMaximumZoomLevelForClustering
 import cocoapods.MapLibre.MLNShapeSourceOptionMinimumZoomLevel
 import cocoapods.MapLibre.MLNShapeSourceOptionSimplificationTolerance
 import dev.sargunv.maplibrecompose.core.expression.Expression
-import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.const
 import dev.sargunv.maplibrecompose.core.util.toMLNShape
 import dev.sargunv.maplibrecompose.core.util.toNSExpression
 import io.github.dellisd.spatialk.geojson.GeoJson
@@ -44,7 +43,7 @@ public actual class GeoJsonSource : Source {
       put(
         MLNShapeSourceOptionClusterProperties,
         options.clusterProperties.mapValues { (_, p) ->
-          Expression.ofList(listOf(const(p.operator), p.mapper)).toNSExpression()
+          Expression.ofList(listOf(p.operator, p.mapper.value)).toNSExpression()
         },
       )
     }


### PR DESCRIPTION
it seems literal lists can't have expressions inside, so updating the expressions DSL typing
