### PR TITLE
fix: correct textVariableAnchor property name

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -204,7 +204,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
   }
 
   actual fun setTextVariableAnchorOffset(variableAnchorOffset: Expression<ListValue<*>>) {
-    impl.textVariableAnchor = variableAnchorOffset.toNSExpression()
+    impl.textVariableAnchorOffset = variableAnchorOffset.toNSExpression()
   }
 
   actual fun setTextAnchor(anchor: Expression<EnumValue<SymbolAnchor>>) {


### PR DESCRIPTION
Fixed incorrect property name when setting text variable anchor offset in iOS symbol layer implementation. The property was incorrectly set as `textVariableAnchor` instead of `textVariableAnchorOffset`.
