### PR TITLE
feat: add state for meters per dp at camera target

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraStateDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraStateDemo.kt
@@ -22,6 +22,7 @@ import dev.sargunv.maplibrecompose.demoapp.Demo
 import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.format
 import io.github.dellisd.spatialk.geojson.Position
+import kotlin.math.roundToInt
 
 private val CHICAGO = Position(latitude = 41.878, longitude = -87.626)
 
@@ -48,11 +49,14 @@ object CameraStateDemo : Demo {
 
         Row(modifier = Modifier.safeDrawingPadding().wrapContentSize(Alignment.Center)) {
           val pos = cameraState.position
+          val scale = cameraState.metersPerDpAtTarget
+
           Cell("Latitude", pos.target.latitude.format(3), Modifier.weight(1.4f))
           Cell("Longitude", pos.target.longitude.format(3), Modifier.weight(1.4f))
           Cell("Zoom", pos.zoom.format(2), Modifier.weight(1f))
           Cell("Bearing", pos.bearing.format(2), Modifier.weight(1f))
           Cell("Tilt", pos.tilt.format(2), Modifier.weight(1f))
+          Cell("Scale", "${scale.roundToInt()}m", Modifier.weight(1f))
         }
       }
     }

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/EdgeToEdgeDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/EdgeToEdgeDemo.kt
@@ -48,13 +48,12 @@ object EdgeToEdgeDemo : Demo {
               isLogoEnabled = false,
               isAttributionEnabled = false,
             ),
-          content = {
-            Box(modifier = Modifier.fillMaxSize().padding(padding).padding(8.dp)) {
-              AttributionButton(styleState, modifier = Modifier.align(Alignment.BottomEnd))
-              CompassButton(cameraState, modifier = Modifier.align(Alignment.TopEnd))
-            }
-          },
-        )
+        ) {
+          Box(modifier = Modifier.fillMaxSize().padding(padding).padding(8.dp)) {
+            AttributionButton(styleState, modifier = Modifier.align(Alignment.BottomEnd))
+            CompassButton(cameraState, modifier = Modifier.align(Alignment.TopEnd))
+          }
+        }
       },
     )
   }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -317,6 +317,9 @@ internal class AndroidMap(
     return query(rect.toRectF(density), predicate?.toMLNExpression(), layerIds?.toTypedArray())
       .map { Feature.fromJson(it.toJson()) }
   }
+
+  override fun metersPerDpAtLatitude(latitude: Double) =
+    map.projection.getMetersPerPixelAtLatitude(latitude) / density.density
 }
 
 private fun MLNVisibleRegion.toVisibleRegion() =

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -40,6 +40,7 @@ public class CameraState internal constructor(firstPosition: CameraPosition) {
 
   internal val positionState = mutableStateOf(firstPosition)
   internal val moveReasonState = mutableStateOf(CameraMoveReason.NONE)
+  internal val metersPerDpAtTargetState = mutableStateOf(0.0)
 
   /** how the camera is oriented towards the map */
   // if the map is not yet initialized, we store the value to apply it later
@@ -53,6 +54,10 @@ public class CameraState internal constructor(firstPosition: CameraPosition) {
   /** reason why the camera moved, last time it moved */
   public val moveReason: CameraMoveReason
     get() = moveReasonState.value
+
+  /** meters per dp at the target position */
+  public val metersPerDpAtTarget: Double
+    get() = metersPerDpAtTargetState.value
 
   /** suspends until the map has been initialized */
   public suspend fun awaitInitialized() {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -108,6 +108,8 @@ public fun MaplibreMap(
         override fun onStyleChanged(map: MaplibreMap, style: Style?) {
           styleState.attach(style)
           rememberedStyle = style
+          cameraState.metersPerDpAtTargetState.value =
+            map.metersPerDpAtLatitude(map.cameraPosition.target.latitude)
         }
 
         override fun onCameraMoveStarted(map: MaplibreMap, reason: CameraMoveReason) {
@@ -116,6 +118,8 @@ public fun MaplibreMap(
 
         override fun onCameraMoved(map: MaplibreMap) {
           cameraState.positionState.value = map.cameraPosition
+          cameraState.metersPerDpAtTargetState.value =
+            map.metersPerDpAtLatitude(map.cameraPosition.target.latitude)
         }
 
         override fun onCameraMoveEnded(map: MaplibreMap) {}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
@@ -43,6 +43,8 @@ internal interface MaplibreMap {
     predicate: Expression<BooleanValue>? = null,
   ): List<Feature>
 
+  fun metersPerDpAtLatitude(latitude: Double): Double
+
   interface Callbacks {
     fun onStyleChanged(map: MaplibreMap, style: Style?)
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -458,4 +458,6 @@ internal class IosMap(
         predicate = predicate?.toNSPredicate(),
       )
       .map { (it as MLNFeatureProtocol).toFeature() }
+
+  override fun metersPerDpAtLatitude(latitude: Double) = mapView.metersPerPointAtLatitude(latitude)
 }


### PR DESCRIPTION
going to use this for a composable scale bar

unsure if density calculation is correct; will confirm with a scale bar implementation before release