### PR TITLE
feat: redo map content api

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/app.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/app.kt
@@ -4,7 +4,9 @@ import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -27,11 +29,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import dev.sargunv.maplibrecompose.compose.CameraState
+import dev.sargunv.maplibrecompose.compose.StyleState
+import dev.sargunv.maplibrecompose.core.OrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.demos.AnimatedLayerDemo
 import dev.sargunv.maplibrecompose.demoapp.demos.CameraFollowDemo
 import dev.sargunv.maplibrecompose.demoapp.demos.CameraStateDemo
@@ -39,6 +46,9 @@ import dev.sargunv.maplibrecompose.demoapp.demos.ClusteredPointsDemo
 import dev.sargunv.maplibrecompose.demoapp.demos.EdgeToEdgeDemo
 import dev.sargunv.maplibrecompose.demoapp.demos.FrameRateDemo
 import dev.sargunv.maplibrecompose.demoapp.demos.StyleSwitcherDemo
+import dev.sargunv.maplibrecompose.material3.controls.AttributionButton
+import dev.sargunv.maplibrecompose.material3.controls.DisappearingCompassButton
+import dev.sargunv.maplibrecompose.material3.controls.DisappearingScaleBar
 
 private val DEMOS =
   listOf(
@@ -139,3 +149,23 @@ fun DemoScaffold(demo: Demo, navigateUp: () -> Unit, content: @Composable () -> 
     },
   )
 }
+
+@Composable
+fun DemoMapControls(
+  cameraState: CameraState,
+  styleState: StyleState,
+  modifier: Modifier = Modifier,
+) {
+  Box(modifier = modifier.fillMaxSize().padding(8.dp)) {
+    DisappearingScaleBar(cameraState, modifier = Modifier.align(Alignment.TopStart))
+    DisappearingCompassButton(cameraState, modifier = Modifier.align(Alignment.TopEnd))
+    AttributionButton(styleState, modifier = Modifier.align(Alignment.BottomEnd))
+  }
+}
+
+fun DemoOrnamentSettings(padding: PaddingValues = PaddingValues(0.dp)) =
+  OrnamentSettings.AllDisabled.copy(
+    padding = padding,
+    isLogoEnabled = true,
+    logoAlignment = Alignment.BottomStart,
+  )

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
@@ -4,14 +4,18 @@ import androidx.compose.animation.animateColor
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.layer.Anchor
 import dev.sargunv.maplibrecompose.compose.layer.LineLayer
 import dev.sargunv.maplibrecompose.compose.rememberCameraState
+import dev.sargunv.maplibrecompose.compose.rememberStyleState
 import dev.sargunv.maplibrecompose.compose.source.rememberGeoJsonSource
 import dev.sargunv.maplibrecompose.core.CameraPosition
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.const
@@ -22,6 +26,8 @@ import dev.sargunv.maplibrecompose.core.expression.LineCap
 import dev.sargunv.maplibrecompose.core.expression.LineJoin
 import dev.sargunv.maplibrecompose.demoapp.DEFAULT_STYLE
 import dev.sargunv.maplibrecompose.demoapp.Demo
+import dev.sargunv.maplibrecompose.demoapp.DemoMapControls
+import dev.sargunv.maplibrecompose.demoapp.DemoOrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.generated.Res
 import io.github.dellisd.spatialk.geojson.Position
@@ -39,10 +45,16 @@ object AnimatedLayerDemo : Demo {
   @OptIn(ExperimentalResourceApi::class)
   override fun Component(navigateUp: () -> Unit) {
     DemoScaffold(this, navigateUp) {
-      MaplibreMap(
-        styleUri = DEFAULT_STYLE,
-        cameraState = rememberCameraState(firstPosition = CameraPosition(target = US, zoom = 2.0)),
-        mapContent = {
+      val cameraState = rememberCameraState(firstPosition = CameraPosition(target = US, zoom = 2.0))
+      val styleState = rememberStyleState()
+
+      Box(modifier = Modifier.fillMaxSize()) {
+        MaplibreMap(
+          styleUri = DEFAULT_STYLE,
+          cameraState = cameraState,
+          styleState = styleState,
+          ornamentSettings = DemoOrnamentSettings(),
+        ) {
           val routeSource =
             rememberGeoJsonSource(id = "amtrak-routes", uri = Res.getUri(ROUTES_FILE))
 
@@ -77,8 +89,9 @@ object AnimatedLayerDemo : Demo {
                 ),
             )
           }
-        },
-      )
+        }
+        DemoMapControls(cameraState, styleState)
+      }
     }
   }
 }

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraStateDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraStateDemo.kt
@@ -1,5 +1,6 @@
 package dev.sargunv.maplibrecompose.demoapp.demos
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -13,12 +14,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import dev.sargunv.maplibrecompose.compose.ClickResult
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.rememberCameraState
+import dev.sargunv.maplibrecompose.compose.rememberStyleState
 import dev.sargunv.maplibrecompose.core.CameraPosition
 import dev.sargunv.maplibrecompose.demoapp.DEFAULT_STYLE
 import dev.sargunv.maplibrecompose.demoapp.Demo
+import dev.sargunv.maplibrecompose.demoapp.DemoMapControls
+import dev.sargunv.maplibrecompose.demoapp.DemoOrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.format
 import io.github.dellisd.spatialk.geojson.Position
@@ -36,16 +39,17 @@ object CameraStateDemo : Demo {
       Column {
         val cameraState =
           rememberCameraState(firstPosition = CameraPosition(target = CHICAGO, zoom = 12.0))
+        val styleState = rememberStyleState()
 
-        MaplibreMap(
-          modifier = Modifier.weight(1f),
-          styleUri = DEFAULT_STYLE,
-          cameraState = cameraState,
-          onMapClick = { _, _ ->
-            println(cameraState.queryVisibleBoundingBox())
-            ClickResult.Pass
-          },
-        )
+        Box(modifier = Modifier.weight(1f)) {
+          MaplibreMap(
+            styleUri = DEFAULT_STYLE,
+            cameraState = cameraState,
+            styleState = styleState,
+            ornamentSettings = DemoOrnamentSettings(),
+          )
+          DemoMapControls(cameraState, styleState)
+        }
 
         Row(modifier = Modifier.safeDrawingPadding().wrapContentSize(Alignment.Center)) {
           val pos = cameraState.position

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -1,5 +1,7 @@
 package dev.sargunv.maplibrecompose.demoapp.demos
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -17,6 +19,7 @@ import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.layer.CircleLayer
 import dev.sargunv.maplibrecompose.compose.layer.SymbolLayer
 import dev.sargunv.maplibrecompose.compose.rememberCameraState
+import dev.sargunv.maplibrecompose.compose.rememberStyleState
 import dev.sargunv.maplibrecompose.compose.source.rememberGeoJsonSource
 import dev.sargunv.maplibrecompose.core.CameraPosition
 import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.asNumber
@@ -29,6 +32,8 @@ import dev.sargunv.maplibrecompose.core.expression.ExpressionsDsl.step
 import dev.sargunv.maplibrecompose.core.source.GeoJsonOptions
 import dev.sargunv.maplibrecompose.demoapp.DEFAULT_STYLE
 import dev.sargunv.maplibrecompose.demoapp.Demo
+import dev.sargunv.maplibrecompose.demoapp.DemoMapControls
+import dev.sargunv.maplibrecompose.demoapp.DemoOrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.generated.Res
 import io.github.dellisd.spatialk.geojson.Feature
@@ -59,14 +64,17 @@ object ClusteredPointsDemo : Demo {
     DemoScaffold(this, navigateUp) {
       val cameraState =
         rememberCameraState(firstPosition = CameraPosition(target = SEATTLE, zoom = 10.0))
+      val styleState = rememberStyleState()
 
       val coroutineScope = rememberCoroutineScope()
 
-      MaplibreMap(
-        modifier = Modifier,
-        styleUri = DEFAULT_STYLE,
-        cameraState = cameraState,
-        mapContent = {
+      Box(modifier = Modifier.fillMaxSize()) {
+        MaplibreMap(
+          styleUri = DEFAULT_STYLE,
+          cameraState = cameraState,
+          styleState = styleState,
+          ornamentSettings = DemoOrnamentSettings(),
+        ) {
           val gbfsData by rememberGbfsFeatureState(GBFS_FILE)
 
           val bikeSource =
@@ -135,8 +143,9 @@ object ClusteredPointsDemo : Demo {
             strokeWidth = const(3.dp),
             strokeColor = const(Color.White),
           )
-        },
-      )
+        }
+        DemoMapControls(cameraState, styleState)
+      }
     }
   }
 }

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/EdgeToEdgeDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/EdgeToEdgeDemo.kt
@@ -1,25 +1,23 @@
 package dev.sargunv.maplibrecompose.demoapp.demos
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContent
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.rememberCameraState
 import dev.sargunv.maplibrecompose.compose.rememberStyleState
 import dev.sargunv.maplibrecompose.core.CameraPosition
-import dev.sargunv.maplibrecompose.core.OrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DEFAULT_STYLE
 import dev.sargunv.maplibrecompose.demoapp.Demo
 import dev.sargunv.maplibrecompose.demoapp.DemoAppBar
-import dev.sargunv.maplibrecompose.material3.controls.AttributionButton
-import dev.sargunv.maplibrecompose.material3.controls.DisappearingCompassButton
-import dev.sargunv.maplibrecompose.material3.controls.DisappearingScaleBar
+import dev.sargunv.maplibrecompose.demoapp.DemoMapControls
+import dev.sargunv.maplibrecompose.demoapp.DemoOrnamentSettings
 import io.github.dellisd.spatialk.geojson.Position
 
 private val PORTLAND = Position(latitude = 45.521, longitude = -122.675)
@@ -37,19 +35,14 @@ object EdgeToEdgeDemo : Demo {
     Scaffold(
       topBar = { DemoAppBar(this, navigateUp, alpha = 0.5f) },
       content = { padding ->
-        MaplibreMap(
-          modifier = Modifier.consumeWindowInsets(padding),
-          styleUri = DEFAULT_STYLE,
-          cameraState = cameraState,
-          styleState = styleState,
-          ornamentSettings =
-            OrnamentSettings.AllDisabled.copy(isLogoEnabled = true, padding = padding),
-        ) {
-          Box(modifier = Modifier.fillMaxSize().padding(padding).padding(8.dp)) {
-            DisappearingScaleBar(cameraState, modifier = Modifier.align(Alignment.TopStart))
-            DisappearingCompassButton(cameraState, modifier = Modifier.align(Alignment.TopEnd))
-            AttributionButton(styleState, modifier = Modifier.align(Alignment.BottomEnd))
-          }
+        Box(modifier = Modifier.consumeWindowInsets(WindowInsets.safeContent).fillMaxSize()) {
+          MaplibreMap(
+            styleUri = DEFAULT_STYLE,
+            cameraState = cameraState,
+            styleState = styleState,
+            ornamentSettings = DemoOrnamentSettings(padding),
+          )
+          DemoMapControls(cameraState, styleState, modifier = Modifier.padding(padding))
         }
       },
     )

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/FrameRateDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/FrameRateDemo.kt
@@ -1,5 +1,6 @@
 package dev.sargunv.maplibrecompose.demoapp.demos
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -13,9 +14,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
+import dev.sargunv.maplibrecompose.compose.rememberCameraState
+import dev.sargunv.maplibrecompose.compose.rememberStyleState
 import dev.sargunv.maplibrecompose.core.util.PlatformUtils
 import dev.sargunv.maplibrecompose.demoapp.DEFAULT_STYLE
 import dev.sargunv.maplibrecompose.demoapp.Demo
+import dev.sargunv.maplibrecompose.demoapp.DemoMapControls
+import dev.sargunv.maplibrecompose.demoapp.DemoOrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.FrameRateState
 import kotlin.math.roundToInt
@@ -32,12 +37,20 @@ object FrameRateDemo : Demo {
         var maximumFps by remember { mutableStateOf(systemRefreshRate) }
         val fpsState = remember { FrameRateState() }
 
-        MaplibreMap(
-          modifier = Modifier.weight(1f),
-          styleUri = DEFAULT_STYLE,
-          maximumFps = maximumFps,
-          onFrame = fpsState::recordFps,
-        )
+        val cameraState = rememberCameraState()
+        val styleState = rememberStyleState()
+
+        Box(modifier = Modifier.weight(1f)) {
+          MaplibreMap(
+            styleUri = DEFAULT_STYLE,
+            maximumFps = maximumFps,
+            onFrame = fpsState::recordFps,
+            cameraState = cameraState,
+            styleState = styleState,
+            ornamentSettings = DemoOrnamentSettings(),
+          )
+          DemoMapControls(cameraState, styleState)
+        }
 
         Column(modifier = Modifier.padding(16.dp)) {
           Slider(

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/StyleSwitcherDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/StyleSwitcherDemo.kt
@@ -1,5 +1,6 @@
 package dev.sargunv.maplibrecompose.demoapp.demos
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
@@ -13,8 +14,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.rememberCameraState
+import dev.sargunv.maplibrecompose.compose.rememberStyleState
 import dev.sargunv.maplibrecompose.core.CameraPosition
 import dev.sargunv.maplibrecompose.demoapp.Demo
+import dev.sargunv.maplibrecompose.demoapp.DemoMapControls
+import dev.sargunv.maplibrecompose.demoapp.DemoOrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.getAllStyleUris
 import io.github.dellisd.spatialk.geojson.Position
@@ -34,12 +38,16 @@ object StyleSwitcherDemo : Demo {
 
         val cameraState =
           rememberCameraState(CameraPosition(target = NEW_YORK, zoom = 15.0, tilt = 30.0))
+        val styleState = rememberStyleState()
 
-        MaplibreMap(
-          modifier = Modifier.weight(1f),
-          styleUri = styles[selectedIndex].second,
-          cameraState = cameraState,
-        )
+        Box(modifier = Modifier.weight(1f)) {
+          MaplibreMap(
+            styleUri = styles[selectedIndex].second,
+            cameraState = cameraState,
+            ornamentSettings = DemoOrnamentSettings(),
+          )
+          DemoMapControls(cameraState, styleState)
+        }
 
         SecondaryScrollableTabRow(selectedTabIndex = selectedIndex) {
           styles.forEachIndexed { index, pair ->

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Layers.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Layers.kt
@@ -25,76 +25,71 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 @OptIn(ExperimentalResourceApi::class)
 fun Layers() {
   // -8<- [start:simple]
-  MaplibreMap(
-    styleUri = "https://tiles.openfreemap.org/styles/liberty",
-    mapContent = {
-      val tiles = getBaseSource(id = "openmaptiles")
-      CircleLayer(id = "example", source = tiles, sourceLayer = "poi")
-    },
-  )
+  MaplibreMap(styleUri = "https://tiles.openfreemap.org/styles/liberty") {
+    val tiles = getBaseSource(id = "openmaptiles")
+    CircleLayer(id = "example", source = tiles, sourceLayer = "poi")
+  }
   // -8<- [end:simple]
 
-  MaplibreMap(
-    mapContent = {
-      val amtrakStations =
-        rememberGeoJsonSource(
-          id = "amtrak-stations",
-          uri = Res.getUri("files/data/amtrak_stations.geojson"),
-        )
-
-      // -8<- [start:amtrak-1]
-      val amtrakRoutes =
-        rememberGeoJsonSource(
-          id = "amtrak-routes",
-          uri = Res.getUri("files/data/amtrak_routes.geojson"),
-        )
-      LineLayer(
-        id = "amtrak-routes-casing",
-        source = amtrakRoutes,
-        color = const(Color.White),
-        width = const(6.dp),
-      )
-      LineLayer(
-        id = "amtrak-routes",
-        source = amtrakRoutes,
-        color = const(Color.Blue),
-        width = const(4.dp),
-      )
-      // -8<- [end:amtrak-1]
-
-      // -8<- [start:amtrak-2]
-      LineLayer(
-        id = "amtrak-routes",
-        source = amtrakRoutes,
-        cap = const(LineCap.Round),
-        join = const(LineJoin.Round),
-        color = const(Color.Blue),
-        width =
-          interpolate(
-            type = exponential(const(1.2f)),
-            input = zoom(),
-            5 to const(0.4.dp),
-            6 to const(0.7.dp),
-            7 to const(1.75.dp),
-            20 to const(22.dp),
-          ),
-      )
-      // -8<- [end:amtrak-2]
-
-      // -8<- [start:anchors]
-      Anchor.Above("road_motorway") { LineLayer(id = "amtrak-routes", source = amtrakRoutes) }
-      // -8<- [end:anchors]
-
-      // -8<- [start:interaction]
-      CircleLayer(
+  MaplibreMap {
+    val amtrakStations =
+      rememberGeoJsonSource(
         id = "amtrak-stations",
-        source = amtrakStations,
-        onClick = { features ->
-          println("Clicked on ${features[0].json()}")
-          ClickResult.Consume
-        },
+        uri = Res.getUri("files/data/amtrak_stations.geojson"),
       )
-      // -8<- [end:interaction]
-    }
-  )
+
+    // -8<- [start:amtrak-1]
+    val amtrakRoutes =
+      rememberGeoJsonSource(
+        id = "amtrak-routes",
+        uri = Res.getUri("files/data/amtrak_routes.geojson"),
+      )
+    LineLayer(
+      id = "amtrak-routes-casing",
+      source = amtrakRoutes,
+      color = const(Color.White),
+      width = const(6.dp),
+    )
+    LineLayer(
+      id = "amtrak-routes",
+      source = amtrakRoutes,
+      color = const(Color.Blue),
+      width = const(4.dp),
+    )
+    // -8<- [end:amtrak-1]
+
+    // -8<- [start:amtrak-2]
+    LineLayer(
+      id = "amtrak-routes",
+      source = amtrakRoutes,
+      cap = const(LineCap.Round),
+      join = const(LineJoin.Round),
+      color = const(Color.Blue),
+      width =
+        interpolate(
+          type = exponential(const(1.2f)),
+          input = zoom(),
+          5 to const(0.4.dp),
+          6 to const(0.7.dp),
+          7 to const(1.75.dp),
+          20 to const(22.dp),
+        ),
+    )
+    // -8<- [end:amtrak-2]
+
+    // -8<- [start:anchors]
+    Anchor.Above("road_motorway") { LineLayer(id = "amtrak-routes", source = amtrakRoutes) }
+    // -8<- [end:anchors]
+
+    // -8<- [start:interaction]
+    CircleLayer(
+      id = "amtrak-stations",
+      source = amtrakStations,
+      onClick = { features ->
+        println("Clicked on ${features[0].json()}")
+        ClickResult.Consume
+      },
+    )
+    // -8<- [end:interaction]
+  }
 }

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Material3.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Material3.kt
@@ -25,11 +25,13 @@ fun Material3() {
   val cameraState = rememberCameraState()
   val styleState = rememberStyleState()
 
-  MaplibreMap(
-    cameraState = cameraState,
-    styleState = styleState,
-    ornamentSettings = OrnamentSettings.AllDisabled,
-  ) {
+  Box(Modifier.fillMaxSize()) {
+    MaplibreMap(
+      cameraState = cameraState,
+      styleState = styleState,
+      ornamentSettings = OrnamentSettings.AllDisabled,
+    )
+
     Box(modifier = Modifier.fillMaxSize().padding(8.dp)) {
       ScaleBar(cameraState, modifier = Modifier.align(Alignment.TopStart))
       CompassButton(cameraState, modifier = Modifier.align(Alignment.TopEnd))
@@ -39,11 +41,13 @@ fun Material3() {
   // -8<- [end:controls]
 
   // -8<- [start:disappearing-controls]
-  MaplibreMap(
-    cameraState = cameraState,
-    styleState = styleState,
-    ornamentSettings = OrnamentSettings.AllDisabled,
-  ) {
+  Box(modifier = Modifier.fillMaxSize()) {
+    MaplibreMap(
+      cameraState = cameraState,
+      styleState = styleState,
+      ornamentSettings = OrnamentSettings.AllDisabled,
+    )
+
     Box(modifier = Modifier.fillMaxSize().padding(8.dp)) {
       DisappearingScaleBar(cameraState, modifier = Modifier.align(Alignment.TopStart)) // (1)!
       DisappearingCompassButton(cameraState, modifier = Modifier.align(Alignment.TopEnd)) // (2)!

--- a/docs/docs/material3.md
+++ b/docs/docs/material3.md
@@ -4,8 +4,9 @@
 
 We provide reimplementations of certain ornaments using Material 3. These are
 regular Compose UI components, so you can position them arbitrarily, style them,
-animate them, etc. To use them, disable the default ornaments and add the
-Material controls to the map's `content`.
+animate them, etc.
+
+To get started, add the dependency to your project:
 
 ```toml title="libs.versions.toml"
 [libraries]
@@ -17,6 +18,9 @@ commonMain.dependencies {
   implementation(libs.maplibre.composeMaterial3)
 }
 ```
+
+Then, disable the default ornaments and add the Material controls after the
+`MaplibreMap` in a shared `Box`.
 
 ```kotlin title="App.kt"
 -8<- "demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Material3.kt:controls"

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -26,7 +26,6 @@ public fun AttributionButton(
   modifier: Modifier = Modifier,
   colors: IconButtonColors = IconButtonDefaults.iconButtonColors(),
   contentDescription: String = "Attribution",
-  confirmText: String = "OK",
 ) {
   var showDialog by remember { mutableStateOf(false) }
 
@@ -40,11 +39,7 @@ public fun AttributionButton(
 
     AlertDialog(
       onDismissRequest = { showDialog = false },
-      confirmButton = {
-        TextButton(onClick = { showDialog = false }) {
-          Text(text = confirmText, style = MaterialTheme.typography.labelLarge)
-        }
-      },
+      confirmButton = {},
       title = { Text(text = "MapLibre Compose", style = MaterialTheme.typography.headlineSmall) },
       text = {
         Column {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -1,7 +1,5 @@
 package dev.sargunv.maplibrecompose.compose
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -43,9 +41,8 @@ import kotlin.math.roundToInt
  * @param maximumFps The maximum frame rate at which the map view is rendered, but it can't exceed
  *   the ability of device hardware.
  * @param logger kermit logger to use
- * @param mapContent The map content additional to what is already part of the map as defined in the
+ * @param content The map content additional to what is already part of the map as defined in the
  *   base map style linked in [styleUri].
- * @param content The composable content shown on top of the map.
  *
  * Additional [sources](https://maplibre.org/maplibre-style-spec/sources/) can be added via:
  * - [rememberGeoJsonSource][dev.sargunv.maplibrecompose.compose.source.rememberGeoJsonSource] (see
@@ -96,11 +93,10 @@ public fun MaplibreMap(
   isDebugEnabled: Boolean = false,
   maximumFps: Int = PlatformUtils.getSystemRefreshRate().roundToInt(),
   logger: Logger? = remember { Logger.withTag("maplibre-compose") },
-  mapContent: @Composable @MaplibreComposable () -> Unit = {},
-  content: @Composable BoxScope.() -> Unit = {},
+  content: @Composable @MaplibreComposable () -> Unit = {},
 ) {
   var rememberedStyle by remember { mutableStateOf<Style?>(null) }
-  val styleComposition by rememberStyleComposition(rememberedStyle, logger, mapContent)
+  val styleComposition by rememberStyleComposition(rememberedStyle, logger, content)
 
   val callbacks =
     remember(cameraState, styleState, styleComposition) {
@@ -162,25 +158,22 @@ public fun MaplibreMap(
       }
     }
 
-  Box(modifier = modifier) {
-    ComposableMapView(
-      modifier = Modifier.fillMaxSize(),
-      styleUri = styleUri,
-      update = { map ->
-        cameraState.map = map
-        map.onFpsChanged = onFrame
-        map.isDebugEnabled = isDebugEnabled
-        map.setGestureSettings(gestureSettings)
-        map.setOrnamentSettings(ornamentSettings)
-        map.setMaximumFps(maximumFps)
-      },
-      onReset = {
-        cameraState.map = null
-        rememberedStyle = null
-      },
-      logger = logger,
-      callbacks = callbacks,
-    )
-    content()
-  }
+  ComposableMapView(
+    modifier = modifier.fillMaxSize(),
+    styleUri = styleUri,
+    update = { map ->
+      cameraState.map = map
+      map.onFpsChanged = onFrame
+      map.isDebugEnabled = isDebugEnabled
+      map.setGestureSettings(gestureSettings)
+      map.setOrnamentSettings(ornamentSettings)
+      map.setMaximumFps(maximumFps)
+    },
+    onReset = {
+      cameraState.map = null
+      rememberedStyle = null
+    },
+    logger = logger,
+    callbacks = callbacks,
+  )
 }


### PR DESCRIPTION
closes #156 

map composables (layers) are the only map content now, like it was before

overlay UI goes next to the map in a shared box

this is similar to the Google Maps Compose API