### PR TITLE
add localized abbreviations for m/km

### DIFF
--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ar/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">متر</string>
-  <string name="kilometers_abbreviation">كم</string>
+  <string name="meters_symbol">متر</string>
+  <string name="kilometers_symbol">كم</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ar/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">متر</string>
+  <string name="kilometers_abbreviation">كم</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-av/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-av/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-av/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-av/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ba/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ba/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ba/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ba/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-be/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-be/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-be/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-be/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bg/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bg/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bg/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bg/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ce/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ce/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ce/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ce/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cu/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cu/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cu/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cu/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cv/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cv/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cv/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cv/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-es/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="feet_symbol">pies</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hy/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hy/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">մ</string>
+  <string name="kilometers_abbreviation">կմ</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hy/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hy/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">մ</string>
-  <string name="kilometers_abbreviation">կմ</string>
+  <string name="meters_symbol">մ</string>
+  <string name="kilometers_symbol">կմ</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ja/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">m</string><!-- 米 not used since 1952 -->
+  <string name="kilometers_abbreviation">km</string><!-- 粁 not used since 1951 -->
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ja/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,4 +1,0 @@
-<resources>
-  <string name="meters_abbreviation">m</string><!-- 米 not used since 1952 -->
-  <string name="kilometers_abbreviation">km</string><!-- 粁 not used since 1951 -->
-</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ka/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ka/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">მ</string>
-  <string name="kilometers_abbreviation">კმ</string>
+  <string name="meters_symbol">მ</string>
+  <string name="kilometers_symbol">კმ</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ka/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ka/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">მ</string>
+  <string name="kilometers_abbreviation">კმ</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kk/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kk/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kk/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kk/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ky/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ky/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ky/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ky/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mk/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mk/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mk/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mk/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mn/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mn/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mn/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mn/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ru/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ru/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tg/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tg/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tg/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tg/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-th/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-th/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">ม</string>
-  <string name="kilometers_abbreviation">กม</string>
+  <string name="meters_symbol">ม</string>
+  <string name="kilometers_symbol">กม</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-th/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-th/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">ม</string>
+  <string name="kilometers_abbreviation">กม</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tt/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tt/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tt/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tt/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-uk/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-uk/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">м</string>
+  <string name="kilometers_abbreviation">км</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-uk/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-uk/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">м</string>
-  <string name="kilometers_abbreviation">км</string>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-zh/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="meters_abbreviation">米</string>
+  <string name="kilometers_abbreviation">千米</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-zh/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="meters_abbreviation">米</string>
-  <string name="kilometers_abbreviation">千米</string>
+  <string name="meters_symbol">米</string>
+  <string name="kilometers_symbol">千米</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+  <string name="meters_abbreviation">m</string>
+  <string name="kilometers_abbreviation">km</string>
+  <string name="feet_abbreviation">ft</string>
+  <string name="miles_abbreviation">mi</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-  <string name="meters_abbreviation">m</string>
-  <string name="kilometers_abbreviation">km</string>
-  <string name="feet_abbreviation">ft</string>
-  <string name="miles_abbreviation">mi</string>
+  <string name="meters_symbol">m</string>
+  <string name="kilometers_symbol">km</string>
+  <string name="feet_symbol">ft</string>
+  <string name="miles_symbol">mi</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
@@ -48,10 +48,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import dev.sargunv.maplibrecompose.compose.CameraState
+import dev.sargunv.maplibrecompose.material3.generated.Res
+import dev.sargunv.maplibrecompose.material3.generated.feet_abbreviation
+import dev.sargunv.maplibrecompose.material3.generated.kilometers_abbreviation
+import dev.sargunv.maplibrecompose.material3.generated.meters_abbreviation
+import dev.sargunv.maplibrecompose.material3.generated.miles_abbreviation
 import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
+import org.jetbrains.compose.resources.stringResource
 
 public data class ScaleBarColors(
   val textColor: Color,
@@ -150,19 +156,19 @@ public fun ScaleBar(
       },
     )
     Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.SpaceAround) {
-      var metricUnits = "m"
+      var metricUnits = stringResource(Res.string.meters_abbreviation)
       var metricDistance = horizontalLineWidthMeters
       if (horizontalLineWidthMeters > METERS_IN_KILOMETER) {
         // Switch from meters to kilometers as unit
-        metricUnits = "km"
+        metricUnits = stringResource(Res.string.kilometers_abbreviation)
         metricDistance /= METERS_IN_KILOMETER.toInt()
       }
 
-      var imperialUnits = "ft"
+      var imperialUnits = stringResource(Res.string.feet_abbreviation)
       var imperialDistance = horizontalLineWidthMeters.toFeet()
       if (imperialDistance > FEET_IN_MILE) {
         // Switch from ft to miles as unit
-        imperialUnits = "mi"
+        imperialUnits = stringResource(Res.string.miles_abbreviation)
         imperialDistance = imperialDistance.toMiles()
       }
 

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
@@ -49,10 +49,10 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import dev.sargunv.maplibrecompose.compose.CameraState
 import dev.sargunv.maplibrecompose.material3.generated.Res
-import dev.sargunv.maplibrecompose.material3.generated.feet_abbreviation
-import dev.sargunv.maplibrecompose.material3.generated.kilometers_abbreviation
-import dev.sargunv.maplibrecompose.material3.generated.meters_abbreviation
-import dev.sargunv.maplibrecompose.material3.generated.miles_abbreviation
+import dev.sargunv.maplibrecompose.material3.generated.feet_symbol
+import dev.sargunv.maplibrecompose.material3.generated.kilometers_symbol
+import dev.sargunv.maplibrecompose.material3.generated.meters_symbol
+import dev.sargunv.maplibrecompose.material3.generated.miles_symbol
 import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -156,19 +156,19 @@ public fun ScaleBar(
       },
     )
     Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.SpaceAround) {
-      var metricUnits = stringResource(Res.string.meters_abbreviation)
+      var metricUnits = stringResource(Res.string.meters_symbol)
       var metricDistance = horizontalLineWidthMeters
       if (horizontalLineWidthMeters > METERS_IN_KILOMETER) {
         // Switch from meters to kilometers as unit
-        metricUnits = stringResource(Res.string.kilometers_abbreviation)
+        metricUnits = stringResource(Res.string.kilometers_symbol)
         metricDistance /= METERS_IN_KILOMETER.toInt()
       }
 
-      var imperialUnits = stringResource(Res.string.feet_abbreviation)
+      var imperialUnits = stringResource(Res.string.feet_symbol)
       var imperialDistance = horizontalLineWidthMeters.toFeet()
       if (imperialDistance > FEET_IN_MILE) {
         // Switch from ft to miles as unit
-        imperialUnits = stringResource(Res.string.miles_abbreviation)
+        imperialUnits = stringResource(Res.string.miles_symbol)
         imperialDistance = imperialDistance.toMiles()
       }
 


### PR DESCRIPTION
Researched by looking at all articles in all languages linked from https://en.wikipedia.org/wiki/Metre 😅

Only added strings.xml for languages that have an ISO 639-1 or ISO 639-2 code. (I.e. not ISO 639-3 because[ that isn't supported anyway](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-resources-setup.html#language-and-regional-qualifiers))

"m" should actually be quite understood anywhere, but some languages have an abbreviation in their own script that is preferred over the international symbol ("m").

There are no translations for feet, because feet is only really used in the US, i.e. in an English-speaking country. Hence, in other languages, an abbreviation doesn't really exist.