### PR TITLE
ci: move snapshots and dependency submission to daily workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,42 +99,6 @@ jobs:
           name: "demo-app-debug"
           path: "demo-app/build/outputs/apk/debug/demo-app-debug.apk"
 
-  publish-snapshot:
-    needs:
-      - "test-android"
-      - "test-ios"
-    if: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}"
-    runs-on: "macos-latest"
-    permissions:
-      packages: "write"
-    steps:
-      - uses: "actions/checkout@v4"
-        with:
-          fetch-depth: 0
-      - uses: "./.github/actions/setup"
-      - run: "./gradlew publishAllPublicationsToGitHubPackagesRepository"
-        env:
-          ORG_GRADLE_PROJECT_githubToken: "${{ secrets.GITHUB_TOKEN }}"
-          ORG_GRADLE_PROJECT_githubUser: "${{ github.actor }}"
-
-  dependency-submission:
-    if: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}"
-    runs-on: "ubuntu-latest"
-    permissions:
-      contents: "write"
-    steps:
-      - uses: "actions/checkout@v4"
-      - uses: "actions/setup-java@v4"
-        with:
-          distribution: "temurin"
-          java-version: 23
-      - uses: "gradle/actions/dependency-submission@v4"
-        with:
-          build-scan-publish: true
-          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
-          build-scan-terms-of-use-agree: "yes"
-      - uses: "advanced-security/cocoapods-dependency-submission-action@v1.1"
-
   all-good:
     needs:
       - "check-format"

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,52 @@
+---
+name: "Daily"
+
+on:
+  schedule:
+    - cron: "00 10 * * *"
+
+jobs:
+  check-last-run:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "octokit/request-action@v2.x"
+        id: "check-last-run"
+        with:
+          route: "GET /repos/${{github.repository}}/actions/workflows/daily.yml/runs?per_page=1&status=completed"
+    outputs:
+      last_sha: "${{ fromJson(steps.check-last-run.outputs.data).workflow_runs[0].head_sha }}"
+
+  publish-snapshot:
+    needs: ["check-last-run"]
+    if: "${{ needs.check-last-run.outputs.last_sha != github.sha }}"
+    runs-on: "macos-latest"
+    permissions:
+      packages: "write"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+      - uses: "./.github/actions/setup"
+      - run: "./gradlew publishAllPublicationsToGitHubPackagesRepository"
+        env:
+          ORG_GRADLE_PROJECT_githubToken: "${{ secrets.GITHUB_TOKEN }}"
+          ORG_GRADLE_PROJECT_githubUser: "${{ github.actor }}"
+
+  dependency-submission:
+    needs: ["check-last-run"]
+    if: "${{ needs.check-last-run.outputs.last_sha != github.sha }}"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: "write"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-java@v4"
+        with:
+          distribution: "temurin"
+          java-version: 23
+      - uses: "gradle/actions/dependency-submission@v4"
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
+          build-scan-terms-of-use-agree: "yes"
+      - uses: "advanced-security/cocoapods-dependency-submission-action@v1.1"


### PR DESCRIPTION
publishing snapshots sometimes fails when I merge many PRs in quick succession. let's switch to publishing at most once a day