### PR TITLE
proof of concept: pass through panning input on web 

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/util.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/util.kt
@@ -88,7 +88,7 @@ val Platform.supportsLayers: Boolean
   get() = isAndroid || isIos
 
 val Platform.supportsBlending: Boolean
-  get() = isAndroid || isIos
+  get() = isAndroid || isIos || isWeb
 
 val Platform.usesMaplibreNative: Boolean
   get() = isAndroid || isIos

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
@@ -15,6 +15,7 @@ import dev.sargunv.maplibrecompose.core.AndroidMap
 import dev.sargunv.maplibrecompose.core.AndroidScaleBar
 import dev.sargunv.maplibrecompose.core.MaplibreMap
 import org.maplibre.android.MapLibre
+import org.maplibre.android.gestures.AndroidGesturesManager
 import org.maplibre.android.maps.MapLibreMapOptions
 import org.maplibre.android.maps.MapView
 
@@ -63,6 +64,12 @@ internal fun AndroidMapView(
         mapView ->
         currentMapView = mapView
         mapView.getMapAsync { map ->
+          map.setGesturesManager(AndroidGesturesManager(context), false, false)
+          mapView.isClickable = false
+          mapView.isLongClickable = false
+          mapView.isFocusable = false
+          mapView.setFocusableInTouchMode(false)
+          mapView.requestDisallowInterceptTouchEvent(false)
           currentMap =
             AndroidMap(
               mapView = mapView,

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -212,15 +212,8 @@ internal class AndroidMap(
   override fun setMaximumFps(maximumFps: Int) = mapView.setMaximumFps(maximumFps)
 
   override fun setGestureSettings(value: GestureSettings) {
-    map.uiSettings.isRotateGesturesEnabled = value.isRotateGesturesEnabled
-    map.uiSettings.isScrollGesturesEnabled = value.isScrollGesturesEnabled
-    map.uiSettings.isTiltGesturesEnabled = value.isTiltGesturesEnabled
-    map.uiSettings.isZoomGesturesEnabled = value.isZoomGesturesEnabled
-    // on iOS, there is no setting for enabling quick zoom (=double-tap, hold and move up or down)
-    // and zoom in by a double tap separately, so isZoomGesturesEnabled turns on or off ALL zoom
-    // gestures
-    map.uiSettings.isQuickZoomGesturesEnabled = value.isZoomGesturesEnabled
-    map.uiSettings.isDoubleTapGesturesEnabled = value.isZoomGesturesEnabled
+    map.uiSettings.setAllGesturesEnabled(false)
+    map.gesturesManager.detectors.clear()
   }
 
   override fun setOrnamentSettings(value: OrnamentSettings) {

--- a/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/WebviewMap.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/WebviewMap.kt
@@ -106,11 +106,11 @@ internal class WebviewMap(private val bridge: WebviewBridge) : MaplibreMap {
   }
 
   override suspend fun asyncSetGestureSettings(value: GestureSettings) {
-    bridge.callVoid("setTiltGesturesEnabled", value.isTiltGesturesEnabled)
-    bridge.callVoid("setZoomGesturesEnabled", value.isZoomGesturesEnabled)
-    bridge.callVoid("setRotateGesturesEnabled", value.isRotateGesturesEnabled)
-    bridge.callVoid("setScrollGesturesEnabled", value.isScrollGesturesEnabled)
-    bridge.callVoid("setKeyboardGesturesEnabled", value.isKeyboardGesturesEnabled)
+    bridge.callVoid("setTiltGesturesEnabled", false)
+    bridge.callVoid("setZoomGesturesEnabled", false)
+    bridge.callVoid("setRotateGesturesEnabled", false)
+    bridge.callVoid("setScrollGesturesEnabled", false)
+    bridge.callVoid("setKeyboardGesturesEnabled", false)
   }
 
   override suspend fun animateCameraPosition(finalPosition: CameraPosition, duration: Duration) {}

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/compose/IosMapView.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/compose/IosMapView.kt
@@ -65,7 +65,9 @@ internal fun IosMapView(
     UIKitView(
       modifier = modifier.fillMaxSize(),
       properties =
-        UIKitInteropProperties(interactionMode = UIKitInteropInteractionMode.NonCooperative),
+        UIKitInteropProperties(
+          interactionMode = UIKitInteropInteractionMode.Cooperative(delayMillis = Int.MAX_VALUE)
+        ),
       factory = {
         MLNMapView(
             frame =

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -41,7 +41,10 @@ import cocoapods.MapLibre.MLNOrnamentPositionTopLeft
 import cocoapods.MapLibre.MLNOrnamentPositionTopRight
 import cocoapods.MapLibre.MLNStyle
 import cocoapods.MapLibre.MLNZoomLevelForAltitude
+import cocoapods.MapLibre.allowsRotating
+import cocoapods.MapLibre.allowsScrolling
 import cocoapods.MapLibre.allowsTilting
+import cocoapods.MapLibre.allowsZooming
 import dev.sargunv.maplibrecompose.core.util.toBoundingBox
 import dev.sargunv.maplibrecompose.core.util.toCGPoint
 import dev.sargunv.maplibrecompose.core.util.toCGRect
@@ -294,10 +297,13 @@ internal class IosMap(
   }
 
   override fun setGestureSettings(value: GestureSettings) {
-    mapView.rotateEnabled = value.isRotateGesturesEnabled
-    mapView.scrollEnabled = value.isScrollGesturesEnabled
-    mapView.allowsTilting = value.isTiltGesturesEnabled
-    mapView.zoomEnabled = value.isZoomGesturesEnabled
+    mapView.rotateEnabled = false
+    mapView.scrollEnabled = false
+    mapView.allowsTilting = false
+    mapView.zoomEnabled = false
+    mapView.allowsZooming = false
+    mapView.allowsScrolling = false
+    mapView.allowsRotating = false
   }
 
   private fun calculateMargins(

--- a/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/compose/WebMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/compose/WebMapView.kt
@@ -51,7 +51,7 @@ internal fun WebMapView(
 
   HtmlElement(
     modifier = modifier.onGloballyPositioned { maybeMap?.resize() },
-    // zIndex = "-1", // TODO figure out pointer interop
+    zIndex = "-1",
     factory = {
       document.createElement("div").unsafeCast<HTMLElement>().apply {
         style.apply {

--- a/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/JsMap.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/JsMap.kt
@@ -132,43 +132,13 @@ internal class JsMap(
   }
 
   override fun setGestureSettings(value: GestureSettings) {
-    if (value.isTiltGesturesEnabled) {
-      impl.touchPitch.enable()
-    } else {
-      impl.touchPitch.disable()
-    }
-
-    if (value.isRotateGesturesEnabled) {
-      impl.dragRotate.enable()
-      impl.keyboard.enableRotation()
-      impl.touchZoomRotate.enableRotation()
-    } else {
-      impl.dragRotate.disable()
-      impl.keyboard.disableRotation()
-      impl.touchZoomRotate.disableRotation()
-    }
-
-    if (value.isScrollGesturesEnabled) {
-      impl.dragPan.enable()
-    } else {
-      impl.dragPan.disable()
-    }
-
-    if (value.isZoomGesturesEnabled) {
-      impl.doubleClickZoom.enable()
-      impl.scrollZoom.enable()
-      impl.touchZoomRotate.enable()
-    } else {
-      impl.doubleClickZoom.disable()
-      impl.scrollZoom.disable()
-      impl.touchZoomRotate.disable()
-    }
-
-    if (value.isKeyboardGesturesEnabled) {
-      impl.keyboard.enable()
-    } else {
-      impl.keyboard.disable()
-    }
+    impl.touchPitch.disable()
+    impl.dragRotate.disable()
+    impl.keyboard.disable()
+    impl.dragPan.disable()
+    impl.doubleClickZoom.disable()
+    impl.scrollZoom.disable()
+    impl.touchZoomRotate.disable()
   }
 
   private var compassPosition: String? = null


### PR DESCRIPTION
We could solve #210 if we reimplement all the gestures to make up for the blocked pointer input. This branch is a proof of concept, with just panning reimplemented in Compose.

Zoom and rotate may be more complex to reimplement, as we need to handle zooming and rotating around a focus. Unsure how `transformable` deals with that (is it built in to offset?)

the standard web ornaments also won't work; replace them with the compose versions?