### PR TITLE
perf: disable texture mode on android

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
@@ -59,7 +59,7 @@ internal fun AndroidMapView(
     modifier = modifier,
     factory = { context ->
       MapLibre.getInstance(context)
-      MapView(context, MapLibreMapOptions.createFromAttributes(context).textureMode(true)).also {
+      MapView(context, MapLibreMapOptions.createFromAttributes(context).textureMode(false)).also {
         mapView ->
         currentMapView = mapView
         mapView.getMapAsync { map ->


### PR DESCRIPTION
Disabled texture mode again in MapLibre's Android map view to improve rendering performance. This has caveats; see #15. A future PR will make this an opt-in option instead, see #217 

previously enabled in #214 