### PR TITLE
fix: removeAt instead of removeLast for SDK <35 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
 
   test-android:
     runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        api-level:
+          - 24
+          - 35
     steps:
       - uses: "actions/checkout@v4"
         with:
@@ -57,7 +62,7 @@ jobs:
       - name: "Run with AVD ./gradlew connectedDebugAndroidTest"
         uses: "./.github/actions/run-with-avd"
         with:
-          api-level: 35
+          api-level: "${{ matrix.api-level }}"
           script: "./gradlew connectedDebugAndroidTest"
 
   test-ios:

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/LayerManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/LayerManager.kt
@@ -85,7 +85,7 @@ internal class LayerManager(private val styleNode: StyleNode) {
     // anything left in missedLayers is a new anchor
     missedLayers.forEach { (anchor, nodes) ->
       // let's initialize the anchor with one layer
-      val tail = nodes.removeLast()
+      val tail = nodes.removeAt(nodes.size - 1)
       styleNode.logger?.i { "Initializing anchor $anchor with layer ${tail.layer.id}" }
       when (anchor) {
         is Anchor.Top -> styleNode.style.addLayer(tail.layer)


### PR DESCRIPTION
Run Android instrumentation tests against API levels 24 and 35, and fix a compatibility issue by using removeAt instead of removeLast.

fixes #224 