### PR TITLE
fix: configure JVM target to a reasonable LTS (11)

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -40,13 +40,19 @@ android {
 
 kotlin {
   androidTarget {
-    compilerOptions { jvmTarget.set(JvmTarget.JVM_11) }
+    compilerOptions {
+      jvmTarget.set(JvmTarget.valueOf(project.properties["jvmTarget"]!!.toString()))
+    }
     instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
   }
   iosArm64()
   iosSimulatorArm64()
   iosX64()
-  jvm("desktop")
+  jvm("desktop") {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.valueOf(project.properties["jvmTarget"]!!.toString()))
+    }
+  }
   js(IR) {
     browser { commonWebpackConfig { outputFileName = "app.js" } }
     binaries.executable()

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ androidMinSdk=23
 androidCompileSdk=35
 androidTargetSdk=35
 iosDeploymentTarget=12.0
+jvmTarget=JVM_11
 kotlin.code.style=official
 kotlin.daemon.jvmargs=-Xmx2048M
 kotlin.incremental.wasm=true

--- a/lib/maplibre-compose-expressions/build.gradle.kts
+++ b/lib/maplibre-compose-expressions/build.gradle.kts
@@ -27,14 +27,20 @@ mavenPublishing {
 
 kotlin {
   androidTarget {
-    compilerOptions { jvmTarget.set(JvmTarget.JVM_11) }
+    compilerOptions {
+      jvmTarget.set(JvmTarget.valueOf(project.properties["jvmTarget"]!!.toString()))
+    }
     instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
     publishLibraryVariants("release", "debug")
   }
   iosArm64()
   iosSimulatorArm64()
   iosX64()
-  jvm("desktop")
+  jvm("desktop") {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.valueOf(project.properties["jvmTarget"]!!.toString()))
+    }
+  }
   js(IR) { browser() }
   wasmJs { browser() }
 

--- a/lib/maplibre-compose-material3/build.gradle.kts
+++ b/lib/maplibre-compose-material3/build.gradle.kts
@@ -28,14 +28,20 @@ mavenPublishing {
 
 kotlin {
   androidTarget {
-    compilerOptions { jvmTarget.set(JvmTarget.JVM_11) }
+    compilerOptions {
+      jvmTarget.set(JvmTarget.valueOf(project.properties["jvmTarget"]!!.toString()))
+    }
     instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
     publishLibraryVariants("release", "debug")
   }
   iosArm64()
   iosSimulatorArm64()
   iosX64()
-  jvm("desktop")
+  jvm("desktop") {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.valueOf(project.properties["jvmTarget"]!!.toString()))
+    }
+  }
   js(IR) { browser() }
 
   cocoapods {

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -47,14 +47,20 @@ val copyDesktopResources by
 
 kotlin {
   androidTarget {
-    compilerOptions { jvmTarget.set(JvmTarget.JVM_11) }
+    compilerOptions {
+      jvmTarget.set(JvmTarget.valueOf(project.properties["jvmTarget"]!!.toString()))
+    }
     instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
     publishLibraryVariants("release", "debug")
   }
   iosArm64()
   iosSimulatorArm64()
   iosX64()
-  jvm("desktop")
+  jvm("desktop") {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.valueOf(project.properties["jvmTarget"]!!.toString()))
+    }
+  }
   js(IR) { browser() }
 
   cocoapods {


### PR DESCRIPTION
Previously we used whatever target we built with (23). But this is a library, so we should be compatible with currently supported LTS versions.

fixes #223 