### PR TITLE
fix type for text-overlap layer property

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -18,6 +18,7 @@ import dev.sargunv.maplibrecompose.expressions.value.ImageValue
 import dev.sargunv.maplibrecompose.expressions.value.ListValue
 import dev.sargunv.maplibrecompose.expressions.value.StringValue
 import dev.sargunv.maplibrecompose.expressions.value.SymbolAnchor
+import dev.sargunv.maplibrecompose.expressions.value.SymbolOverlap
 import dev.sargunv.maplibrecompose.expressions.value.SymbolPlacement
 import dev.sargunv.maplibrecompose.expressions.value.SymbolZOrder
 import dev.sargunv.maplibrecompose.expressions.value.TextJustify
@@ -242,7 +243,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.textAllowOverlap(allowOverlap.toMLNExpression()))
   }
 
-  actual fun setTextOverlap(overlap: CompiledExpression<StringValue>) {
+  actual fun setTextOverlap(overlap: CompiledExpression<SymbolOverlap>) {
     // not implemented by MapLibre-native Android yet
     // impl.setProperties(PropertyFactory.textOverlap(overlap.toMLNExpression()))
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -34,6 +34,7 @@ import dev.sargunv.maplibrecompose.expressions.value.ImageValue
 import dev.sargunv.maplibrecompose.expressions.value.ListValue
 import dev.sargunv.maplibrecompose.expressions.value.StringValue
 import dev.sargunv.maplibrecompose.expressions.value.SymbolAnchor
+import dev.sargunv.maplibrecompose.expressions.value.SymbolOverlap
 import dev.sargunv.maplibrecompose.expressions.value.SymbolPlacement
 import dev.sargunv.maplibrecompose.expressions.value.SymbolZOrder
 import dev.sargunv.maplibrecompose.expressions.value.TextJustify
@@ -344,8 +345,8 @@ import dev.sargunv.maplibrecompose.expressions.value.TranslateAnchor
  *   Ignored if [textField] is not specified.
  *
  * @param textOverlap Controls whether to show an icon/text when it overlaps other symbols on the
- *   map. See [SymbolOverlap][dev.sargunv.maplibrecompose.expressions.SymbolOverlap]. Overrides
- *   [textAllowOverlap].
+ *   map. See [SymbolOverlap][dev.sargunv.maplibrecompose.expressions.value.SymbolOverlap].
+ *   Overrides [textAllowOverlap].
  *
  *   Ignored if [textField] is not specified.
  *
@@ -462,7 +463,7 @@ public fun SymbolLayer(
   // text collision
   textPadding: Expression<DpValue> = const(2.dp),
   textAllowOverlap: Expression<BooleanValue> = const(false),
-  textOverlap: Expression<StringValue> = nil(),
+  textOverlap: Expression<SymbolOverlap> = nil(),
   textIgnorePlacement: Expression<BooleanValue> = const(false),
   textOptional: Expression<BooleanValue> = const(false),
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -17,6 +17,7 @@ import dev.sargunv.maplibrecompose.expressions.value.ImageValue
 import dev.sargunv.maplibrecompose.expressions.value.ListValue
 import dev.sargunv.maplibrecompose.expressions.value.StringValue
 import dev.sargunv.maplibrecompose.expressions.value.SymbolAnchor
+import dev.sargunv.maplibrecompose.expressions.value.SymbolOverlap
 import dev.sargunv.maplibrecompose.expressions.value.SymbolPlacement
 import dev.sargunv.maplibrecompose.expressions.value.SymbolZOrder
 import dev.sargunv.maplibrecompose.expressions.value.TextJustify
@@ -130,7 +131,7 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setTextAllowOverlap(allowOverlap: CompiledExpression<BooleanValue>)
 
-  fun setTextOverlap(overlap: CompiledExpression<StringValue>)
+  fun setTextOverlap(overlap: CompiledExpression<SymbolOverlap>)
 
   fun setTextIgnorePlacement(ignorePlacement: CompiledExpression<BooleanValue>)
 

--- a/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -17,6 +17,7 @@ import dev.sargunv.maplibrecompose.expressions.value.ImageValue
 import dev.sargunv.maplibrecompose.expressions.value.ListValue
 import dev.sargunv.maplibrecompose.expressions.value.StringValue
 import dev.sargunv.maplibrecompose.expressions.value.SymbolAnchor
+import dev.sargunv.maplibrecompose.expressions.value.SymbolOverlap
 import dev.sargunv.maplibrecompose.expressions.value.SymbolPlacement
 import dev.sargunv.maplibrecompose.expressions.value.SymbolZOrder
 import dev.sargunv.maplibrecompose.expressions.value.TextJustify
@@ -235,7 +236,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     TODO()
   }
 
-  actual fun setTextOverlap(overlap: CompiledExpression<StringValue>) {
+  actual fun setTextOverlap(overlap: CompiledExpression<SymbolOverlap>) {
     TODO()
   }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -21,6 +21,7 @@ import dev.sargunv.maplibrecompose.expressions.value.ImageValue
 import dev.sargunv.maplibrecompose.expressions.value.ListValue
 import dev.sargunv.maplibrecompose.expressions.value.StringValue
 import dev.sargunv.maplibrecompose.expressions.value.SymbolAnchor
+import dev.sargunv.maplibrecompose.expressions.value.SymbolOverlap
 import dev.sargunv.maplibrecompose.expressions.value.SymbolPlacement
 import dev.sargunv.maplibrecompose.expressions.value.SymbolZOrder
 import dev.sargunv.maplibrecompose.expressions.value.TextJustify
@@ -246,7 +247,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.textAllowsOverlap = allowOverlap.toNSExpression()
   }
 
-  actual fun setTextOverlap(overlap: CompiledExpression<StringValue>) {
+  actual fun setTextOverlap(overlap: CompiledExpression<SymbolOverlap>) {
     // not implemented by MapLibre-native iOS yet
     // impl.textOverlap = overlap.toNSExpression()
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -17,6 +17,7 @@ import dev.sargunv.maplibrecompose.expressions.value.ImageValue
 import dev.sargunv.maplibrecompose.expressions.value.ListValue
 import dev.sargunv.maplibrecompose.expressions.value.StringValue
 import dev.sargunv.maplibrecompose.expressions.value.SymbolAnchor
+import dev.sargunv.maplibrecompose.expressions.value.SymbolOverlap
 import dev.sargunv.maplibrecompose.expressions.value.SymbolPlacement
 import dev.sargunv.maplibrecompose.expressions.value.SymbolZOrder
 import dev.sargunv.maplibrecompose.expressions.value.TextJustify
@@ -235,7 +236,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     TODO()
   }
 
-  actual fun setTextOverlap(overlap: CompiledExpression<StringValue>) {
+  actual fun setTextOverlap(overlap: CompiledExpression<SymbolOverlap>) {
     TODO()
   }
 


### PR DESCRIPTION
the `text-overla`p property for the symbol layer had the wrong type. (It's not functional currently anyway, though, because it is not supported on MapLibre-native. But on MapLibre-Js it is supported)