### PR TITLE
scale bar: slight performance improvement

### DIFF
--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util.kt
@@ -34,7 +34,7 @@ internal fun defaultSecondaryMeasure(primary: ScaleBarMeasure, region: String?):
   }
 
 internal val regionsUsingFeetAndMiles =
-  listOf(
+  setOf(
     // United states and its unincorporated territories
     "US",
     "AS",
@@ -51,7 +51,7 @@ internal val regionsUsingFeetAndMiles =
   )
 
 internal val regionsUsingYardsAndMiles =
-  listOf(
+  setOf(
     // United kingdom with its overseas territories and crown dependencies
     "GB",
     "AI",


### PR DESCRIPTION
after all, the `defaultScaleBarMeasures` is now called every frame.

(If it wasn't `@Composable`, it could also be `remember`ed)

---

I was previously looking into performance improvements on the scalebar, after all, quite a lot is going on there. But basically any attempt to let the scalebar compose less often is sabotaged by the fact that any change in latitude or zoom will make it recompose anyway, as the `metersPerDp` changes.

`metersPerDp` could maybe be rounded, the trick would be to find out at which precision it starts to matter (i.e. be visible on the scalebar). Then, it would generally not recompose when scrolling around in an area, only when one zooms.