### PR TITLE
attribution button with bar

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/app.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/app.kt
@@ -166,7 +166,12 @@ fun DemoMapControls(
         modifier = Modifier.align(Alignment.TopEnd),
         onClick = onCompassClick,
       )
-      AttributionButton(styleState, modifier = Modifier.align(Alignment.BottomEnd))
+      val attributionLinks = remember { styleState.queryAttributionLinks() }
+      AttributionButton(
+        lastCameraMoveReason = cameraState.moveReason,
+        attributions = attributionLinks,
+        modifier = Modifier.align(Alignment.BottomEnd)
+      )
     }
   }
 }

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Material3.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Material3.kt
@@ -36,12 +36,9 @@ fun Material3() {
     Box(modifier = Modifier.fillMaxSize().padding(8.dp)) {
       ScaleBar(
         metersPerDp = cameraState.metersPerDpAtTarget,
-        modifier = Modifier.align(Alignment.TopStart)
+        modifier = Modifier.align(Alignment.TopStart),
       )
-      CompassButton(
-        cameraState = cameraState,
-        modifier = Modifier.align(Alignment.TopEnd)
-      )
+      CompassButton(cameraState = cameraState, modifier = Modifier.align(Alignment.TopEnd))
       val attributionLinks = remember { styleState.queryAttributionLinks() }
       AttributionButton(
         lastCameraMoveReason = cameraState.moveReason,

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Material3.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Material3.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -33,9 +34,20 @@ fun Material3() {
     )
 
     Box(modifier = Modifier.fillMaxSize().padding(8.dp)) {
-      ScaleBar(cameraState.metersPerDpAtTarget, modifier = Modifier.align(Alignment.TopStart))
-      CompassButton(cameraState, modifier = Modifier.align(Alignment.TopEnd))
-      AttributionButton(styleState, modifier = Modifier.align(Alignment.BottomEnd))
+      ScaleBar(
+        metersPerDp = cameraState.metersPerDpAtTarget,
+        modifier = Modifier.align(Alignment.TopStart)
+      )
+      CompassButton(
+        cameraState = cameraState,
+        modifier = Modifier.align(Alignment.TopEnd)
+      )
+      val attributionLinks = remember { styleState.queryAttributionLinks() }
+      AttributionButton(
+        lastCameraMoveReason = cameraState.moveReason,
+        attributions = attributionLinks,
+        modifier = Modifier.align(Alignment.BottomEnd)
+      )
     }
   }
   // -8<- [end:controls]
@@ -54,8 +66,16 @@ fun Material3() {
         zoom = cameraState.position.zoom,
         modifier = Modifier.align(Alignment.TopStart),
       ) // (1)!
-      DisappearingCompassButton(cameraState, modifier = Modifier.align(Alignment.TopEnd)) // (2)!
-      AttributionButton(styleState, modifier = Modifier.align(Alignment.BottomEnd))
+      DisappearingCompassButton(
+        cameraState = cameraState,
+        modifier = Modifier.align(Alignment.TopEnd)
+      ) // (2)!
+      val attributionLinks = remember { styleState.queryAttributionLinks() }
+      AttributionButton(
+        lastCameraMoveReason = cameraState.moveReason,
+        attributions = attributionLinks,
+        modifier = Modifier.align(Alignment.BottomEnd)
+      )
     }
   }
   // -8<- [end:disappearing-controls]

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Alignment.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Alignment.kt
@@ -1,0 +1,49 @@
+package dev.sargunv.maplibrecompose.material3
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+
+private val Alignment.horizontalBias: Float get() {
+  val align = align(IntSize.Zero, IntSize(10_000_000, 1), LayoutDirection.Ltr)
+  return align.x / 5_000_000f - 1f
+}
+
+internal val Alignment.horizontal: Alignment.Horizontal get() =
+  BiasAlignment.Horizontal(horizontalBias)
+
+private val Alignment.verticalBias: Float get() {
+  val align = align(IntSize.Zero, IntSize(1, 10_000_000), LayoutDirection.Ltr)
+  return align.y / 5_000_000f - 1f
+}
+
+internal val Alignment.vertical: Alignment.Vertical get() =
+  BiasAlignment.Vertical(verticalBias)
+
+internal fun Alignment.Horizontal.toArrangement(): Arrangement.Horizontal {
+  val align = align(0, 2, LayoutDirection.Ltr)
+  return when {
+    align < 1 -> Arrangement.Start
+    align == 1 -> Arrangement.Center
+    align > 1 -> Arrangement.End
+    else -> Arrangement.Start
+  }
+}
+
+internal fun Alignment.Vertical.toArrangement(): Arrangement.Vertical {
+  val align = align(0, 2)
+  return when {
+    align < 1 -> Arrangement.Top
+    align == 1 -> Arrangement.Center
+    align > 1 -> Arrangement.Bottom
+    else -> Arrangement.Top
+  }
+}
+
+internal fun LayoutDirection.reverse(): LayoutDirection =
+  when (this) {
+    LayoutDirection.Ltr -> LayoutDirection.Rtl
+    LayoutDirection.Rtl -> LayoutDirection.Ltr
+  }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Alignment.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Alignment.kt
@@ -6,21 +6,23 @@ import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 
-private val Alignment.horizontalBias: Float get() {
-  val align = align(IntSize.Zero, IntSize(10_000_000, 1), LayoutDirection.Ltr)
-  return align.x / 5_000_000f - 1f
-}
+private val Alignment.horizontalBias: Float
+  get() {
+    val align = align(IntSize.Zero, IntSize(10_000_000, 1), LayoutDirection.Ltr)
+    return align.x / 5_000_000f - 1f
+  }
 
-internal val Alignment.horizontal: Alignment.Horizontal get() =
-  BiasAlignment.Horizontal(horizontalBias)
+internal val Alignment.horizontal: Alignment.Horizontal
+  get() = BiasAlignment.Horizontal(horizontalBias)
 
-private val Alignment.verticalBias: Float get() {
-  val align = align(IntSize.Zero, IntSize(1, 10_000_000), LayoutDirection.Ltr)
-  return align.y / 5_000_000f - 1f
-}
+private val Alignment.verticalBias: Float
+  get() {
+    val align = align(IntSize.Zero, IntSize(1, 10_000_000), LayoutDirection.Ltr)
+    return align.y / 5_000_000f - 1f
+  }
 
-internal val Alignment.vertical: Alignment.Vertical get() =
-  BiasAlignment.Vertical(verticalBias)
+internal val Alignment.vertical: Alignment.Vertical
+  get() = BiasAlignment.Vertical(verticalBias)
 
 internal fun Alignment.Horizontal.toArrangement(): Arrangement.Horizontal {
   val align = align(0, 2, LayoutDirection.Ltr)

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -114,7 +114,9 @@ public fun AttributionButton(
         )
       }
 
-      Row(horizontalArrangement = Arrangement.Start, verticalAlignment = Alignment.CenterVertically
+      Row(
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically
       ) {
         InfoIconButton(
           onClick = { expanded = !expanded },

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -108,10 +108,10 @@ public fun AttributionButton(
       // background for the attribution texts
       AnimatedVisibility(expanded, modifier = Modifier.matchParentSize()) {
         Box(
-          modifier = Modifier
-            .matchParentSize()
-            .padding(4.dp)
-            .background(surfaceColor, RoundedCornerShape(cornerSize))
+          modifier =
+            Modifier.matchParentSize()
+              .padding(4.dp)
+              .background(surfaceColor, RoundedCornerShape(cornerSize))
         )
       }
 

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -1,61 +1,91 @@
 package dev.sargunv.maplibrecompose.material3.controls
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalUriHandler
-import dev.sargunv.maplibrecompose.compose.StyleState
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.dp
+import dev.sargunv.maplibrecompose.core.source.AttributionLink
 import dev.sargunv.maplibrecompose.material3.generated.Res
 import dev.sargunv.maplibrecompose.material3.generated.attribution
-import dev.sargunv.maplibrecompose.material3.generated.library_name
 import org.jetbrains.compose.resources.stringResource
 
+/**
+ * Info button from which an attribution text is expanded towards the start. The attribution text
+ * should (optionally) retract when the user starts interacting with the map.
+ *
+ * @param attributions List of attributions to show
+ * @param onClick Called when the info button is clicked. Should expand the attribution.
+ * @param expanded Whether the attribution info is shown next to the info button. It should start
+ *   out as expanded, then retract when the user interacts with the map
+ * @param modifier the Modifier to be applied to this layout node
+ * @param colors Colors that will be used for the info button
+ * @param textStyle Text style used for the attribution info
+ * @param textLinkStyles Text link styles that should be used for the links in the attribution info
+ * */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 public fun AttributionButton(
-  styleState: StyleState,
+  attributions: List<AttributionLink>,
+  onClick: () -> Unit,
   modifier: Modifier = Modifier,
+  expanded: Boolean = true,
   colors: IconButtonColors = IconButtonDefaults.iconButtonColors(),
+  textStyle: TextStyle = MaterialTheme.typography.bodyMedium,
+  textLinkStyles: TextLinkStyles? = null,
 ) {
-  var showDialog by remember { mutableStateOf(false) }
+  if (attributions.isEmpty()) return
 
-  IconButton(modifier = modifier, colors = colors, onClick = { showDialog = true }) {
-    Icon(Icons.Outlined.Info, contentDescription = stringResource(Res.string.attribution))
-  }
-
-  if (showDialog) {
-    val attributions = remember(styleState) { styleState.queryAttributionLinks() }
-    val uriHandler = LocalUriHandler.current
-
-    AlertDialog(
-      onDismissRequest = { showDialog = false },
-      confirmButton = {},
-      title = {
-        Text(
-          text = stringResource(Res.string.library_name),
-          style = MaterialTheme.typography.headlineSmall,
-        )
-      },
-      text = {
-        Column {
-          attributions.forEach {
-            TextButton(onClick = { uriHandler.openUri(it.url) }) { Text(text = it.title) }
+  Row(
+    modifier = modifier,
+    horizontalArrangement = Arrangement.End,
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    AnimatedVisibility(expanded, modifier = Modifier.weight(1f, fill = false)) {
+      Surface(shape = MaterialTheme.shapes.medium) {
+        ProvideTextStyle(textStyle) {
+          FlowRow(
+            modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
+            verticalArrangement = Arrangement.Bottom,
+          ) {
+            attributions.forEach {
+              val text = buildAnnotatedString {
+                withLink(LinkAnnotation.Url(url = it.url, styles = textLinkStyles)) {
+                  append(it.title)
+                }
+              }
+              Text(text)
+            }
           }
         }
-      },
-    )
+      }
+    }
+    IconButton(onClick = onClick, modifier = Modifier.align(Alignment.Bottom), colors = colors) {
+      Icon(
+        imageVector = Icons.Outlined.Info,
+        contentDescription = stringResource(Res.string.attribution)
+      )
+    }
   }
 }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -102,21 +102,20 @@ public fun AttributionButton(
 
   CompositionLocalProvider(
     LocalContentColor provides contentColor,
-    LocalLayoutDirection provides rowLayoutDirection
+    LocalLayoutDirection provides rowLayoutDirection,
   ) {
     Box(modifier = modifier, contentAlignment = Alignment.CenterStart) {
-
       AnimatedVisibility(expanded, modifier = Modifier.matchParentSize()) {
         Box(
           Modifier.matchParentSize()
-          .padding(4.dp)
-          .background(surfaceColor, RoundedCornerShape(cornerSize))
+            .padding(4.dp)
+            .background(surfaceColor, RoundedCornerShape(cornerSize))
         )
       }
 
       Row(
         horizontalArrangement = Arrangement.Start,
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
       ) {
         InfoIconButton(
           onClick = { expanded = !expanded },
@@ -163,14 +162,13 @@ private fun AttributionTexts(
   modifier: Modifier = Modifier,
 ) {
   ProvideTextStyle(textStyle) {
-    FlowRow(
-      modifier = modifier,
-      horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
+    FlowRow(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
       attributions.forEach {
-        Text(buildAnnotatedString {
-          withLink(LinkAnnotation.Url(url = it.url, styles = textLinkStyles)) { append(it.title) }
-        })
+        Text(
+          buildAnnotatedString {
+            withLink(LinkAnnotation.Url(url = it.url, styles = textLinkStyles)) { append(it.title) }
+          }
+        )
       }
     }
   }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -1,22 +1,32 @@
 package dev.sargunv.maplibrecompose.material3.controls
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.LinkAnnotation
@@ -25,6 +35,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
+import dev.sargunv.maplibrecompose.compose.CameraState
+import dev.sargunv.maplibrecompose.core.CameraMoveReason
 import dev.sargunv.maplibrecompose.core.source.AttributionLink
 import dev.sargunv.maplibrecompose.material3.generated.Res
 import dev.sargunv.maplibrecompose.material3.generated.attribution
@@ -32,60 +44,112 @@ import org.jetbrains.compose.resources.stringResource
 
 /**
  * Info button from which an attribution text is expanded towards the start. The attribution text
- * should (optionally) retract when the user starts interacting with the map.
+ * retracts when the user starts interacting with the map.
  *
- * @param attributions List of attributions to show
- * @param onClick Called when the info button is clicked. Should expand the attribution.
- * @param expanded Whether the attribution info is shown next to the info button. It should start
- *   out as expanded, then retract when the user interacts with the map
+ * @param lastCameraMoveReason The reason reason why the camera moved, last time it moved. See
+ *   [CameraState.moveReason]. (The attribution text will automatically retract when the map is
+ *   moved by the user.)
+ * @param attributions List of attributions to show. See
+ *   [StyleState.queryAttributionLinks][dev.sargunv.maplibrecompose.compose.StyleState.queryAttributionLinks]
  * @param modifier the Modifier to be applied to this layout node
  * @param colors Colors that will be used for the info button
  * @param textStyle Text style used for the attribution info
  * @param textLinkStyles Text link styles that should be used for the links in the attribution info
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 public fun AttributionButton(
+  lastCameraMoveReason: CameraMoveReason,
   attributions: List<AttributionLink>,
-  onClick: () -> Unit,
   modifier: Modifier = Modifier,
-  expanded: Boolean = true,
   colors: IconButtonColors = IconButtonDefaults.iconButtonColors(),
   textStyle: TextStyle = MaterialTheme.typography.bodyMedium,
   textLinkStyles: TextLinkStyles? = null,
 ) {
   if (attributions.isEmpty()) return
 
-  Row(
-    modifier = modifier,
-    horizontalArrangement = Arrangement.End,
-    verticalAlignment = Alignment.CenterVertically,
-  ) {
-    AnimatedVisibility(expanded, modifier = Modifier.weight(1f, fill = false)) {
-      Surface(shape = MaterialTheme.shapes.medium) {
-        ProvideTextStyle(textStyle) {
-          FlowRow(
-            modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
-            verticalArrangement = Arrangement.Bottom,
-          ) {
-            attributions.forEach {
-              val text = buildAnnotatedString {
-                withLink(LinkAnnotation.Url(url = it.url, styles = textLinkStyles)) {
-                  append(it.title)
-                }
-              }
-              Text(text)
-            }
-          }
+  var expanded by remember { mutableStateOf(true) }
+
+  LaunchedEffect(lastCameraMoveReason) {
+    if (lastCameraMoveReason == CameraMoveReason.GESTURE) {
+      expanded = false
+    }
+  }
+
+  val surfaceColor = MaterialTheme.colorScheme.surface
+  val contentColor = contentColorFor(surfaceColor)
+  // rounded corner the size of the info button
+  val cornerSize = 24.dp
+
+  Box(modifier = modifier, contentAlignment = Alignment.BottomEnd) {
+    // the background is separate from the attribution texts because it should, when visible, also
+    // cover the info icon button
+    AnimatedVisibility(expanded, modifier = Modifier.matchParentSize()) {
+      Box(Modifier
+        .matchParentSize()
+        .padding(4.dp)
+        .background(surfaceColor, RoundedCornerShape(cornerSize))
+      )
+    }
+    CompositionLocalProvider(LocalContentColor provides contentColor) {
+      Row(
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        AnimatedVisibility(expanded, modifier = Modifier.weight(1f, fill = false)) {
+          AttributionTexts(
+            attributions = attributions,
+            // make sure that the text always fits in the rounded corner background
+            modifier = Modifier.padding(vertical = 4.dp).padding(start = cornerSize - 4.dp),
+            textStyle = textStyle,
+            textLinkStyles = textLinkStyles
+          )
         }
+        InfoIconButton(
+          onClick = { expanded = !expanded },
+          colors = colors,
+          modifier = Modifier.align(Alignment.Bottom)
+        )
       }
     }
-    IconButton(onClick = onClick, modifier = Modifier.align(Alignment.Bottom), colors = colors) {
-      Icon(
-        imageVector = Icons.Outlined.Info,
-        contentDescription = stringResource(Res.string.attribution),
-      )
+  }
+}
+
+@Composable
+private fun InfoIconButton(
+  onClick: () -> Unit,
+  colors: IconButtonColors,
+  modifier: Modifier = Modifier,
+) {
+  IconButton(onClick = onClick, modifier = modifier, colors = colors) {
+    Icon(
+      imageVector = Icons.Outlined.Info,
+      contentDescription = stringResource(Res.string.attribution),
+    )
+  }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun AttributionTexts(
+  attributions: List<AttributionLink>,
+  textStyle: TextStyle,
+  textLinkStyles: TextLinkStyles?,
+  modifier: Modifier = Modifier,
+) {
+  ProvideTextStyle(textStyle) {
+    FlowRow(
+      modifier = modifier,
+      horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
+      verticalArrangement = Arrangement.Bottom,
+    ) {
+      attributions.forEach {
+        val text = buildAnnotatedString {
+          withLink(LinkAnnotation.Url(url = it.url, styles = textLinkStyles)) {
+            append(it.title)
+          }
+        }
+        Text(text)
+      }
     }
   }
 }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -42,7 +42,7 @@ import org.jetbrains.compose.resources.stringResource
  * @param colors Colors that will be used for the info button
  * @param textStyle Text style used for the attribution info
  * @param textLinkStyles Text link styles that should be used for the links in the attribution info
- * */
+ */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 public fun AttributionButton(
@@ -59,7 +59,7 @@ public fun AttributionButton(
   Row(
     modifier = modifier,
     horizontalArrangement = Arrangement.End,
-    verticalAlignment = Alignment.CenterVertically
+    verticalAlignment = Alignment.CenterVertically,
   ) {
     AnimatedVisibility(expanded, modifier = Modifier.weight(1f, fill = false)) {
       Surface(shape = MaterialTheme.shapes.medium) {
@@ -84,7 +84,7 @@ public fun AttributionButton(
     IconButton(onClick = onClick, modifier = Modifier.align(Alignment.Bottom), colors = colors) {
       Icon(
         imageVector = Icons.Outlined.Info,
-        contentDescription = stringResource(Res.string.attribution)
+        contentDescription = stringResource(Res.string.attribution),
       )
     }
   }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -49,11 +49,10 @@ import org.jetbrains.compose.resources.stringResource
 
 /**
  * Info button from which an attribution text is expanded towards the start. The attribution text
- * retracts when the user starts interacting with the map.
+ * retracts once when the user first starts interacting with the map.
  *
  * @param lastCameraMoveReason The reason reason why the camera moved, last time it moved. See
- *   [CameraState.moveReason]. (The attribution text will automatically retract when the map is
- *   moved by the user.)
+ *   [CameraState.moveReason].
  * @param attributions List of attributions to show. See
  *   [StyleState.queryAttributionLinks][dev.sargunv.maplibrecompose.compose.StyleState.queryAttributionLinks]
  * @param modifier the Modifier to be applied to this layout node
@@ -76,15 +75,15 @@ public fun AttributionButton(
 
   var expanded by remember { mutableStateOf(true) }
 
-  val verticalAlignment = remember(contentAlignment) { contentAlignment.vertical }
-  val horizontalArrangement =
-    remember(contentAlignment) { contentAlignment.horizontal.toArrangement() }
-
   LaunchedEffect(lastCameraMoveReason) {
     if (lastCameraMoveReason == CameraMoveReason.GESTURE) {
       expanded = false
     }
   }
+
+  val verticalAlignment = remember(contentAlignment) { contentAlignment.vertical }
+  val horizontalArrangement =
+    remember(contentAlignment) { contentAlignment.horizontal.toArrangement() }
 
   // rounded corner the size of the info button
   val cornerSize = 20.dp
@@ -96,7 +95,8 @@ public fun AttributionButton(
   val surfaceColor = MaterialTheme.colorScheme.surface
   val contentColor = contentColorFor(surfaceColor)
 
-  // reverse the layout if necessary: the info button should always stick to the aligned side
+  // reverse the layout if necessary: the info button should always stick to the side the whole
+  // widget is aligned to
   val dir = LocalLayoutDirection.current
   val rowLayoutDirection = if (horizontalArrangement == Arrangement.End) dir.reverse() else dir
 
@@ -105,9 +105,11 @@ public fun AttributionButton(
     LocalLayoutDirection provides rowLayoutDirection,
   ) {
     Box(modifier = modifier, contentAlignment = Alignment.CenterStart) {
+      // background for the attribution texts
       AnimatedVisibility(expanded, modifier = Modifier.matchParentSize()) {
         Box(
-          Modifier.matchParentSize()
+          modifier = Modifier
+            .matchParentSize()
             .padding(4.dp)
             .background(surfaceColor, RoundedCornerShape(cornerSize))
         )
@@ -122,6 +124,8 @@ public fun AttributionButton(
           colors = colors,
           modifier = Modifier.align(verticalAlignment),
         )
+        // attributions texts: after applying the paddings, they should be layout in the normal
+        // layout direction again
         AnimatedVisibility(expanded, modifier = Modifier.weight(1f, fill = false)) {
           // make sure that the text always fits in the rounded corner background
           Box(Modifier.padding(vertical = 8.dp).padding(end = cornerSize - 4.dp)) {

--- a/lib/maplibre-compose-material3/src/commonTest/kotlin/dev/sargunv/maplibrecompose/material3/AlignmentKtTest.kt
+++ b/lib/maplibre-compose-material3/src/commonTest/kotlin/dev/sargunv/maplibrecompose/material3/AlignmentKtTest.kt
@@ -1,0 +1,66 @@
+package dev.sargunv.maplibrecompose.material3
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AlignmentKtTest {
+
+  @Test
+  fun alignmentHorizontal() {
+    assertEquals(Alignment.Start, Alignment.TopStart.horizontal)
+    assertEquals(Alignment.Start, Alignment.CenterStart.horizontal)
+    assertEquals(Alignment.Start, Alignment.BottomStart.horizontal)
+
+    assertEquals(Alignment.CenterHorizontally, Alignment.TopCenter.horizontal)
+    assertEquals(Alignment.CenterHorizontally, Alignment.Center.horizontal)
+    assertEquals(Alignment.CenterHorizontally, Alignment.BottomCenter.horizontal)
+
+    assertEquals(Alignment.End, Alignment.TopEnd.horizontal)
+    assertEquals(Alignment.End, Alignment.CenterEnd.horizontal)
+    assertEquals(Alignment.End, Alignment.BottomEnd.horizontal)
+  }
+
+  @Test
+  fun alignmentHorizontalBias() {
+    assertEquals(BiasAlignment.Horizontal(0.75f), BiasAlignment(0.75f, 0.0f).horizontal)
+    assertEquals(BiasAlignment.Horizontal(-0.3f), BiasAlignment(-0.3f, 0.0f).horizontal)
+  }
+
+  @Test
+  fun alignmentVertical() {
+    assertEquals(Alignment.Top, Alignment.TopStart.vertical)
+    assertEquals(Alignment.Top, Alignment.TopCenter.vertical)
+    assertEquals(Alignment.Top, Alignment.TopEnd.vertical)
+
+    assertEquals(Alignment.CenterVertically, Alignment.CenterStart.vertical)
+    assertEquals(Alignment.CenterVertically, Alignment.Center.vertical)
+    assertEquals(Alignment.CenterVertically, Alignment.CenterEnd.vertical)
+
+    assertEquals(Alignment.Bottom, Alignment.BottomStart.vertical)
+    assertEquals(Alignment.Bottom, Alignment.BottomCenter.vertical)
+    assertEquals(Alignment.Bottom, Alignment.BottomEnd.vertical)
+  }
+
+  @Test
+  fun alignmentVerticalBias() {
+    assertEquals(BiasAlignment.Vertical(0.75f), BiasAlignment(0.0f, 0.75f).vertical)
+    assertEquals(BiasAlignment.Vertical(-0.3f), BiasAlignment(0.0f, -0.3f).vertical)
+  }
+
+  @Test
+  fun horizontalArrangement() {
+    assertEquals(Arrangement.Start, Alignment.Start.toArrangement())
+    assertEquals(Arrangement.Center, Alignment.CenterHorizontally.toArrangement())
+    assertEquals(Arrangement.End, Alignment.End.toArrangement())
+  }
+
+  @Test
+  fun verticalArrangement() {
+    assertEquals(Arrangement.Top, Alignment.Top.toArrangement())
+    assertEquals(Arrangement.Center, Alignment.CenterVertically.toArrangement())
+    assertEquals(Arrangement.Bottom, Alignment.Bottom.toArrangement())
+  }
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/dev/sargunv/maplibrecompose/compose/StyleNodeTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/dev/sargunv/maplibrecompose/compose/StyleNodeTest.kt
@@ -42,7 +42,7 @@ abstract class StyleNodeTest {
   @BeforeTest open fun platformSetup() {}
 
   @Test
-  fun shoudGetBaseSource() = runComposeUiTest {
+  fun shouldGetBaseSource() = runComposeUiTest {
     runOnUiThread {
       val s = makeStyleNode()
       assertEquals(testSources[1], s.sourceManager.getBaseSource("bar"))


### PR DESCRIPTION
Fixes #174

https://github.com/user-attachments/assets/ba1407b3-8951-461d-86e2-6faaf145395e

I deviated from my suggestion in #174 because:
- **No dialog:** there's not really the need for a dialog, if the attribution text(s) are too long, they can just wrap to several lines
- **No Text buttons but links in text**: fully native and JS implementation is incoming. This means that parsing the attribution text+link will be redone and probably parsed directly to `AnnotatedString`s 
![imagen](https://github.com/user-attachments/assets/61946a38-3d25-4524-98b8-7990d9376cf3)
  which will enable to (correctly) have only parts of the attribution text link to the attribution source, as it should be and as it is done in MapLibre JS.
- **no button background**: personal taste, I guess. IMO the info button should not look like a regular (but smaller?) map button like the compass, etc. because it's rather related to the map than to the HUD-like UI on top of the map (just like the scalebar). It would IMO look weird to have a smaller mis-aligned button amongst other map buttons. Also, if the attribution text is shown fully before map move, it's quite fine to make this button somewhat unobtrusive. Anyway, I think this can be customized anyway with `IconButtonColors`? (didn't try)

I briefly tried out to give the info button 1px white halo, like the scalebar has, but in my eyes, this looked a bit disruptive, even though one would think it would look consistent with the scalebar.

### Question:
- should the text links by default be styled? I am surprised there is no default styling for text links in Compose. E.g. colored like text buttons, with underscore-effect on hover.

### TODO:
- The attribution _should_ automatically retract when the map is being interacted with (i.e. moved) by the user. But I think there is no API for that yet, right?