### PR TITLE
Made CompassButton more customizable

### DIFF
--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/CompassButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/CompassButton.kt
@@ -47,7 +47,7 @@ public fun CompassButton(
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
   contentDescription: String = stringResource(Res.string.compass),
   size: Dp = 48.dp,
-  contentPadding: PaddingValues = PaddingValues(8.dp),
+  contentPadding: PaddingValues = PaddingValues(size / 6),
   shape: Shape = CircleShape,
   needlePainter: Painter = painterResource(Res.drawable.compass_needle),
 ) {
@@ -85,7 +85,7 @@ public fun DisappearingCompassButton(
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
   contentDescription: String = stringResource(Res.string.compass),
   size: Dp = 48.dp,
-  contentPadding: PaddingValues = PaddingValues(8.dp),
+  contentPadding: PaddingValues = PaddingValues(size / 6),
   shape: Shape = CircleShape,
   needlePainter: Painter = painterResource(Res.drawable.compass_needle),
   visibilityDuration: Duration = 1.seconds,

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/CompassButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/CompassButton.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.CameraState
 import dev.sargunv.maplibrecompose.material3.generated.Res
@@ -42,11 +44,13 @@ public fun CompassButton(
   modifier: Modifier = Modifier,
   onClick: () -> Unit = {},
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
-  contentDescription: String = "Compass",
+  contentDescription: String = stringResource(Res.string.compass),
+  size: Dp = 48.dp,
+  needlePainter: Painter = painterResource(Res.drawable.compass_needle),
 ) {
   val coroutineScope = rememberCoroutineScope()
   ElevatedButton(
-    modifier = modifier.size(48.dp).aspectRatio(1f),
+    modifier = modifier.size(size).aspectRatio(1f),
     onClick = {
       coroutineScope.launch {
         cameraState.animateTo(cameraState.position.copy(bearing = 0.0, tilt = 0.0))
@@ -58,7 +62,7 @@ public fun CompassButton(
     contentPadding = PaddingValues(8.dp),
   ) {
     Image(
-      painter = painterResource(Res.drawable.compass_needle),
+      painter = needlePainter,
       contentDescription = contentDescription,
       modifier =
         Modifier.fillMaxSize()
@@ -76,6 +80,9 @@ public fun DisappearingCompassButton(
   modifier: Modifier = Modifier,
   onClick: () -> Unit = {},
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
+  contentDescription: String = stringResource(Res.string.compass),
+  size: Dp = 48.dp,
+  needlePainter: Painter = painterResource(Res.drawable.compass_needle),
   visibilityDuration: Duration = 1.seconds,
   enterTransition: EnterTransition = fadeIn(),
   exitTransition: ExitTransition = fadeOut(),
@@ -108,7 +115,9 @@ public fun DisappearingCompassButton(
       modifier = modifier,
       onClick = onClick,
       colors = colors,
-      contentDescription = stringResource(Res.string.compass),
+      contentDescription = contentDescription,
+      size = size,
+      needlePainter = needlePainter
     )
   }
 }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/CompassButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/CompassButton.kt
@@ -117,7 +117,7 @@ public fun DisappearingCompassButton(
       colors = colors,
       contentDescription = contentDescription,
       size = size,
-      needlePainter = needlePainter
+      needlePainter = needlePainter,
     )
   }
 }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/CompassButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/CompassButton.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Dp
@@ -46,6 +47,8 @@ public fun CompassButton(
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
   contentDescription: String = stringResource(Res.string.compass),
   size: Dp = 48.dp,
+  contentPadding: PaddingValues = PaddingValues(8.dp),
+  shape: Shape = CircleShape,
   needlePainter: Painter = painterResource(Res.drawable.compass_needle),
 ) {
   val coroutineScope = rememberCoroutineScope()
@@ -57,9 +60,9 @@ public fun CompassButton(
       }
       onClick()
     },
-    shape = CircleShape,
+    shape = shape,
     colors = colors,
-    contentPadding = PaddingValues(8.dp),
+    contentPadding = contentPadding,
   ) {
     Image(
       painter = needlePainter,
@@ -82,6 +85,8 @@ public fun DisappearingCompassButton(
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
   contentDescription: String = stringResource(Res.string.compass),
   size: Dp = 48.dp,
+  contentPadding: PaddingValues = PaddingValues(8.dp),
+  shape: Shape = CircleShape,
   needlePainter: Painter = painterResource(Res.drawable.compass_needle),
   visibilityDuration: Duration = 1.seconds,
   enterTransition: EnterTransition = fadeIn(),
@@ -117,6 +122,8 @@ public fun DisappearingCompassButton(
       colors = colors,
       contentDescription = contentDescription,
       size = size,
+      contentPadding = contentPadding,
+      shape = shape,
       needlePainter = needlePainter,
     )
   }


### PR DESCRIPTION
As discussed in #250, I made Compass Button more customizable:

- allowed setting the size of the button
- allowed setting drawable of the needle

In addition, 2 changes that seemed reasonable:
- allowed setting content description of DisappearingCompassButton
- set the default content description of CompassButton to string resource, instead of hardcoded string