### PR TITLE
Getting specific type of source, querying source features on android and expose sources

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidStyle.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidStyle.kt
@@ -9,10 +9,10 @@ import dev.sargunv.maplibrecompose.core.source.RasterSource
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.source.UnknownSource
 import dev.sargunv.maplibrecompose.core.source.VectorSource
-import org.maplibre.android.style.sources.GeoJsonSource as MLNGeoJsonSource
-import org.maplibre.android.style.sources.VectorSource as MLNVectorSource
-import org.maplibre.android.style.sources.RasterSource as MLNRasterSource
 import org.maplibre.android.maps.Style as MLNStyle
+import org.maplibre.android.style.sources.GeoJsonSource as MLNGeoJsonSource
+import org.maplibre.android.style.sources.RasterSource as MLNRasterSource
+import org.maplibre.android.style.sources.VectorSource as MLNVectorSource
 
 internal class AndroidStyle(style: MLNStyle) : Style {
   private var impl: MLNStyle = style

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidStyle.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidStyle.kt
@@ -12,6 +12,7 @@ import dev.sargunv.maplibrecompose.core.source.VectorSource
 import org.maplibre.android.maps.Style as MLNStyle
 import org.maplibre.android.style.sources.GeoJsonSource as MLNGeoJsonSource
 import org.maplibre.android.style.sources.RasterSource as MLNRasterSource
+import org.maplibre.android.style.sources.Source as MLNSource
 import org.maplibre.android.style.sources.VectorSource as MLNVectorSource
 
 internal class AndroidStyle(style: MLNStyle) : Style {
@@ -25,26 +26,20 @@ internal class AndroidStyle(style: MLNStyle) : Style {
     impl.removeImage(id)
   }
 
-  override fun getSource(id: String): Source? {
-    return impl.getSource(id)?.let {
-      when (it) {
-        is MLNVectorSource -> VectorSource(it)
-        is MLNGeoJsonSource -> GeoJsonSource(it)
-        is MLNRasterSource -> RasterSource(it)
-        else -> UnknownSource(it)
-      }
+  private fun MLNSource.toSource() =
+    when (this) {
+      is MLNVectorSource -> VectorSource(this)
+      is MLNGeoJsonSource -> GeoJsonSource(this)
+      is MLNRasterSource -> RasterSource(this)
+      else -> UnknownSource(this)
     }
+
+  override fun getSource(id: String): Source? {
+    return impl.getSource(id)?.toSource()
   }
 
   override fun getSources(): List<Source> {
-    return impl.sources.map {
-      when (it) {
-        is MLNVectorSource -> VectorSource(it)
-        is MLNGeoJsonSource -> GeoJsonSource(it)
-        is MLNRasterSource -> RasterSource(it)
-        else -> UnknownSource(it)
-      }
-    }
+    return impl.sources.map { it.toSource() }
   }
 
   override fun addSource(source: Source) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidStyle.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidStyle.kt
@@ -4,8 +4,14 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import dev.sargunv.maplibrecompose.core.layer.Layer
 import dev.sargunv.maplibrecompose.core.layer.UnknownLayer
+import dev.sargunv.maplibrecompose.core.source.GeoJsonSource
+import dev.sargunv.maplibrecompose.core.source.RasterSource
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.source.UnknownSource
+import dev.sargunv.maplibrecompose.core.source.VectorSource
+import org.maplibre.android.style.sources.GeoJsonSource as MLNGeoJsonSource
+import org.maplibre.android.style.sources.VectorSource as MLNVectorSource
+import org.maplibre.android.style.sources.RasterSource as MLNRasterSource
 import org.maplibre.android.maps.Style as MLNStyle
 
 internal class AndroidStyle(style: MLNStyle) : Style {
@@ -20,11 +26,25 @@ internal class AndroidStyle(style: MLNStyle) : Style {
   }
 
   override fun getSource(id: String): Source? {
-    return impl.getSource(id)?.let { UnknownSource(it) }
+    return impl.getSource(id)?.let {
+      when (it) {
+        is MLNVectorSource -> VectorSource(it)
+        is MLNGeoJsonSource -> GeoJsonSource(it)
+        is MLNRasterSource -> RasterSource(it)
+        else -> UnknownSource(it)
+      }
+    }
   }
 
   override fun getSources(): List<Source> {
-    return impl.sources.map { UnknownSource(it) }
+    return impl.sources.map {
+      when (it) {
+        is MLNVectorSource -> VectorSource(it)
+        is MLNGeoJsonSource -> GeoJsonSource(it)
+        is MLNRasterSource -> RasterSource(it)
+        else -> UnknownSource(it)
+      }
+    }
   }
 
   override fun addSource(source: Source) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -12,7 +12,7 @@ import org.maplibre.android.style.sources.GeoJsonSource as MLNGeoJsonSource
 public actual class GeoJsonSource : Source {
   override val impl: MLNGeoJsonSource
 
-  public constructor(source: MLNGeoJsonSource) {
+  internal constructor(source: MLNGeoJsonSource) {
     impl = source
   }
 

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -12,6 +12,10 @@ import org.maplibre.android.style.sources.GeoJsonSource as MLNGeoJsonSource
 public actual class GeoJsonSource : Source {
   override val impl: MLNGeoJsonSource
 
+  public constructor(source: MLNGeoJsonSource) {
+    impl = source
+  }
+
   public actual constructor(id: String, uri: String, options: GeoJsonOptions) {
     impl = MLNGeoJsonSource(id, URI(uri.correctedAndroidUri()), buildOptionMap(options))
   }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
@@ -3,7 +3,14 @@ package dev.sargunv.maplibrecompose.core.source
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
 import org.maplibre.android.style.sources.RasterSource
 
-public actual class RasterSource actual constructor(id: String, uri: String, tileSize: Int) :
-  Source() {
-  override val impl: RasterSource = RasterSource(id, uri.correctedAndroidUri(), tileSize)
+public actual class RasterSource : Source {
+  override val impl: RasterSource
+
+  public constructor(source: RasterSource) {
+    impl = source
+  }
+
+  public actual constructor(id: String, uri: String, tileSize: Int) {
+    impl = RasterSource(id, uri.correctedAndroidUri(), tileSize)
+  }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
@@ -1,16 +1,16 @@
 package dev.sargunv.maplibrecompose.core.source
 
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
-import org.maplibre.android.style.sources.RasterSource
+import org.maplibre.android.style.sources.RasterSource as MLNRasterSource
 
 public actual class RasterSource : Source {
-  override val impl: RasterSource
+  override val impl: MLNRasterSource
 
-  public constructor(source: RasterSource) {
+  internal constructor(source: MLNRasterSource) {
     impl = source
   }
 
   public actual constructor(id: String, uri: String, tileSize: Int) {
-    impl = RasterSource(id, uri.correctedAndroidUri(), tileSize)
+    impl = MLNRasterSource(id, uri.correctedAndroidUri(), tileSize)
   }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -2,7 +2,9 @@ package dev.sargunv.maplibrecompose.core.source
 
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
 import dev.sargunv.maplibrecompose.core.util.toMLNExpression
-import dev.sargunv.maplibrecompose.expressions.ast.CompiledExpression
+import dev.sargunv.maplibrecompose.expressions.ExpressionContext
+import dev.sargunv.maplibrecompose.expressions.ast.Expression
+import dev.sargunv.maplibrecompose.expressions.dsl.const
 import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import io.github.dellisd.spatialk.geojson.Feature
 import org.maplibre.android.style.sources.VectorSource
@@ -20,10 +22,12 @@ public actual class VectorSource : Source {
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,
-    predicate: CompiledExpression<BooleanValue>?,
+    predicate: Expression<BooleanValue>,
   ): List<Feature> {
+    val predicateOrNull =
+      predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
     return impl
-      .querySourceFeatures(sourceLayerIds.toTypedArray(), predicate?.toMLNExpression())
+      .querySourceFeatures(sourceLayerIds.toTypedArray(), predicateOrNull?.toMLNExpression())
       .map { Feature.fromJson(it.toJson()) }
   }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -3,6 +3,14 @@ package dev.sargunv.maplibrecompose.core.source
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
 import org.maplibre.android.style.sources.VectorSource
 
-public actual class VectorSource actual constructor(id: String, uri: String) : Source() {
-  override val impl: VectorSource = VectorSource(id, uri.correctedAndroidUri())
+public actual class VectorSource : Source {
+  override val impl: VectorSource
+
+  public constructor(source: VectorSource) {
+    impl = source
+  }
+
+  public actual constructor(id: String, uri: String) {
+    impl = VectorSource(id, uri.correctedAndroidUri())
+  }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -7,17 +7,17 @@ import dev.sargunv.maplibrecompose.expressions.ast.Expression
 import dev.sargunv.maplibrecompose.expressions.dsl.const
 import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import io.github.dellisd.spatialk.geojson.Feature
-import org.maplibre.android.style.sources.VectorSource
+import org.maplibre.android.style.sources.VectorSource as MLNVectorSource
 
 public actual class VectorSource : Source {
-  override val impl: VectorSource
+  override val impl: MLNVectorSource
 
-  public constructor(source: VectorSource) {
+  internal constructor(source: MLNVectorSource) {
     impl = source
   }
 
   public actual constructor(id: String, uri: String) {
-    impl = VectorSource(id, uri.correctedAndroidUri())
+    impl = MLNVectorSource(id, uri.correctedAndroidUri())
   }
 
   public actual fun querySourceFeatures(

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -24,10 +24,15 @@ public actual class VectorSource : Source {
     sourceLayerIds: Set<String>,
     predicate: Expression<BooleanValue>,
   ): List<Feature> {
-    val predicateOrNull =
-      predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
     return impl
-      .querySourceFeatures(sourceLayerIds.toTypedArray(), predicateOrNull?.toMLNExpression())
+      .querySourceFeatures(
+        sourceLayerIds = sourceLayerIds.toTypedArray(),
+        filter =
+          predicate
+            .takeUnless { it == const(true) }
+            ?.compile(ExpressionContext.None)
+            ?.toMLNExpression(),
+      )
       .map { Feature.fromJson(it.toJson()) }
   }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -20,9 +20,10 @@ public actual class VectorSource : Source {
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,
-    predicate: CompiledExpression<BooleanValue>?
+    predicate: CompiledExpression<BooleanValue>?,
   ): List<Feature> {
-    return impl.querySourceFeatures(sourceLayerIds.toTypedArray(), predicate?.toMLNExpression())
+    return impl
+      .querySourceFeatures(sourceLayerIds.toTypedArray(), predicate?.toMLNExpression())
       .map { Feature.fromJson(it.toJson()) }
   }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,6 +1,10 @@
 package dev.sargunv.maplibrecompose.core.source
 
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
+import dev.sargunv.maplibrecompose.core.util.toMLNExpression
+import dev.sargunv.maplibrecompose.expressions.ast.CompiledExpression
+import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
+import io.github.dellisd.spatialk.geojson.Feature
 import org.maplibre.android.style.sources.VectorSource
 
 public actual class VectorSource : Source {
@@ -12,5 +16,13 @@ public actual class VectorSource : Source {
 
   public actual constructor(id: String, uri: String) {
     impl = VectorSource(id, uri.correctedAndroidUri())
+  }
+
+  public actual fun querySourceFeatures(
+    sourceLayerIds: Set<String>,
+    predicate: CompiledExpression<BooleanValue>?
+  ): List<Feature> {
+    return impl.querySourceFeatures(sourceLayerIds.toTypedArray(), predicate?.toMLNExpression())
+      .map { Feature.fromJson(it.toJson()) }
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import dev.sargunv.maplibrecompose.core.Style
 import dev.sargunv.maplibrecompose.core.source.AttributionLink
+import dev.sargunv.maplibrecompose.core.source.Source
 
 @Composable
 public fun rememberStyleState(): StyleState {
@@ -23,4 +24,8 @@ public class StyleState internal constructor() {
     // TODO expose this as State somehow?
     return style?.getSources()?.flatMap { it.attributionLinks } ?: emptyList()
   }
+
+  public fun getSources(): List<Source> = style?.getSources() ?: emptyList()
+
+  public fun getSource(id: String): Source? = style?.getSource(id)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
@@ -25,7 +25,18 @@ public class StyleState internal constructor() {
     return style?.getSources()?.flatMap { it.attributionLinks } ?: emptyList()
   }
 
+  /**
+   * Retrieves all sources from the style.
+   *
+   * @return A list of sources, or an empty list if the style is null or has no sources.
+   */
   public fun getSources(): List<Source> = style?.getSources() ?: emptyList()
 
+  /**
+   * Retrieves a source by its [id].
+   *
+   * @param id The ID of the source to retrieve.
+   * @return The source with the specified ID, or null if no such source exists.
+   */
   public fun getSource(id: String): Source? = style?.getSource(id)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -12,5 +12,8 @@ import io.github.dellisd.spatialk.geojson.Feature
  *   [TileJSON specification](https://github.com/mapbox/tilejson-spec/)
  */
 public expect class VectorSource(id: String, uri: String) : Source {
-  public fun querySourceFeatures(sourceLayerIds: Set<String>, predicate: CompiledExpression<BooleanValue>?): List<Feature>
+  public fun querySourceFeatures(
+    sourceLayerIds: Set<String>,
+    predicate: CompiledExpression<BooleanValue>?,
+  ): List<Feature>
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,5 +1,9 @@
 package dev.sargunv.maplibrecompose.core.source
 
+import dev.sargunv.maplibrecompose.expressions.ast.CompiledExpression
+import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
+import io.github.dellisd.spatialk.geojson.Feature
+
 /**
  * A map data source of tiled vector data.
  *
@@ -7,4 +11,6 @@ package dev.sargunv.maplibrecompose.core.source
  * @param uri URI pointing to a JSON file that conforms to the
  *   [TileJSON specification](https://github.com/mapbox/tilejson-spec/)
  */
-public expect class VectorSource(id: String, uri: String) : Source
+public expect class VectorSource(id: String, uri: String) : Source {
+  public fun querySourceFeatures(sourceLayerIds: Set<String>, predicate: CompiledExpression<BooleanValue>?): List<Feature>
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,6 +1,7 @@
 package dev.sargunv.maplibrecompose.core.source
 
-import dev.sargunv.maplibrecompose.expressions.ast.CompiledExpression
+import dev.sargunv.maplibrecompose.expressions.ast.Expression
+import dev.sargunv.maplibrecompose.expressions.dsl.const
 import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import io.github.dellisd.spatialk.geojson.Feature
 
@@ -14,6 +15,6 @@ import io.github.dellisd.spatialk.geojson.Feature
 public expect class VectorSource(id: String, uri: String) : Source {
   public fun querySourceFeatures(
     sourceLayerIds: Set<String>,
-    predicate: CompiledExpression<BooleanValue>?,
+    predicate: Expression<BooleanValue> = const(true),
   ): List<Feature>
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -13,6 +13,16 @@ import io.github.dellisd.spatialk.geojson.Feature
  *   [TileJSON specification](https://github.com/mapbox/tilejson-spec/)
  */
 public expect class VectorSource(id: String, uri: String) : Source {
+  /**
+   * Returns a list of features from the vector source, limited to source layers with the given
+   * [sourceLayerIds] and filtered by the given [predicate].
+   *
+   * @param sourceLayerIds A set of source layer IDs to query features from.
+   * @param predicate An expression used to filter the features. If not specified, all features from
+   *   the vector source are returned.
+   * @return A list of features that match the query, or an empty list if the [sourceLayerIds] is
+   *   empty or no features are found.
+   */
   public fun querySourceFeatures(
     sourceLayerIds: Set<String>,
     predicate: Expression<BooleanValue> = const(true),

--- a/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -9,7 +9,7 @@ public actual class VectorSource actual constructor(id: String, uri: String) : S
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,
-    predicate: CompiledExpression<BooleanValue>?
+    predicate: CompiledExpression<BooleanValue>?,
   ): List<Feature> {
     TODO()
   }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,6 +1,6 @@
 package dev.sargunv.maplibrecompose.core.source
 
-import dev.sargunv.maplibrecompose.expressions.ast.CompiledExpression
+import dev.sargunv.maplibrecompose.expressions.ast.Expression
 import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import io.github.dellisd.spatialk.geojson.Feature
 
@@ -9,7 +9,7 @@ public actual class VectorSource actual constructor(id: String, uri: String) : S
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,
-    predicate: CompiledExpression<BooleanValue>?,
+    predicate: Expression<BooleanValue>,
   ): List<Feature> {
     TODO()
   }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,5 +1,16 @@
 package dev.sargunv.maplibrecompose.core.source
 
+import dev.sargunv.maplibrecompose.expressions.ast.CompiledExpression
+import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
+import io.github.dellisd.spatialk.geojson.Feature
+
 public actual class VectorSource actual constructor(id: String, uri: String) : Source() {
   override val impl: Nothing = TODO()
+
+  public actual fun querySourceFeatures(
+    sourceLayerIds: Set<String>,
+    predicate: CompiledExpression<BooleanValue>?
+  ): List<Feature> {
+    TODO()
+  }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosStyle.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosStyle.kt
@@ -1,13 +1,19 @@
 package dev.sargunv.maplibrecompose.core
 
 import androidx.compose.ui.graphics.ImageBitmap
+import cocoapods.MapLibre.MLNRasterTileSource
+import cocoapods.MapLibre.MLNShapeSource
 import cocoapods.MapLibre.MLNSource
 import cocoapods.MapLibre.MLNStyle
 import cocoapods.MapLibre.MLNStyleLayer
+import cocoapods.MapLibre.MLNVectorTileSource
 import dev.sargunv.maplibrecompose.core.layer.Layer
 import dev.sargunv.maplibrecompose.core.layer.UnknownLayer
+import dev.sargunv.maplibrecompose.core.source.GeoJsonSource
+import dev.sargunv.maplibrecompose.core.source.RasterSource
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.core.source.UnknownSource
+import dev.sargunv.maplibrecompose.core.source.VectorSource
 import dev.sargunv.maplibrecompose.core.util.toUIImage
 
 internal class IosStyle(style: MLNStyle, private val getScale: () -> Float) : Style {
@@ -21,12 +27,20 @@ internal class IosStyle(style: MLNStyle, private val getScale: () -> Float) : St
     impl.removeImageForName(id)
   }
 
+  private fun MLNSource.toSource() =
+    when (this) {
+      is MLNVectorTileSource -> VectorSource(this)
+      is MLNShapeSource -> GeoJsonSource(this)
+      is MLNRasterTileSource -> RasterSource(this)
+      else -> UnknownSource(this)
+    }
+
   override fun getSource(id: String): Source? {
-    return impl.sourceWithIdentifier(id)?.let { UnknownSource(it) }
+    return impl.sourceWithIdentifier(id)?.toSource()
   }
 
   override fun getSources(): List<Source> {
-    return impl.sources.map { UnknownSource(it as MLNSource) }
+    return impl.sources.map { (it as MLNSource).toSource() }
   }
 
   override fun addSource(source: Source) {

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -21,6 +21,10 @@ import platform.Foundation.NSURL
 public actual class GeoJsonSource : Source {
   override val impl: MLNShapeSource
 
+  internal constructor(source: MLNShapeSource) {
+    impl = source
+  }
+
   public actual constructor(id: String, uri: String, options: GeoJsonOptions) {
     impl =
       MLNShapeSource(identifier = id, URL = NSURL(string = uri), options = buildOptionMap(options))

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/RasterSource.kt
@@ -3,8 +3,14 @@ package dev.sargunv.maplibrecompose.core.source
 import cocoapods.MapLibre.MLNRasterTileSource
 import platform.Foundation.NSURL
 
-public actual class RasterSource actual constructor(id: String, uri: String, tileSize: Int) :
-  Source() {
-  override val impl: MLNRasterTileSource =
-    MLNRasterTileSource(id, NSURL(string = uri), tileSize.toDouble())
+public actual class RasterSource : Source {
+  override val impl: MLNRasterTileSource
+
+  internal constructor(source: MLNRasterTileSource) {
+    this.impl = source
+  }
+
+  public actual constructor(id: String, uri: String, tileSize: Int) : super() {
+    this.impl = MLNRasterTileSource(id, NSURL(string = uri), tileSize.toDouble())
+  }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,7 +1,7 @@
 package dev.sargunv.maplibrecompose.core.source
 
 import cocoapods.MapLibre.MLNVectorTileSource
-import dev.sargunv.maplibrecompose.expressions.ast.CompiledExpression
+import dev.sargunv.maplibrecompose.expressions.ast.Expression
 import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import io.github.dellisd.spatialk.geojson.Feature
 import platform.Foundation.NSURL
@@ -11,7 +11,7 @@ public actual class VectorSource actual constructor(id: String, uri: String) : S
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,
-    predicate: CompiledExpression<BooleanValue>?,
+    predicate: Expression<BooleanValue>,
   ): List<Feature> {
     TODO()
   }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,7 +1,12 @@
 package dev.sargunv.maplibrecompose.core.source
 
+import cocoapods.MapLibre.MLNFeatureProtocol
 import cocoapods.MapLibre.MLNVectorTileSource
+import dev.sargunv.maplibrecompose.core.util.toFeature
+import dev.sargunv.maplibrecompose.core.util.toNSPredicate
+import dev.sargunv.maplibrecompose.expressions.ExpressionContext
 import dev.sargunv.maplibrecompose.expressions.ast.Expression
+import dev.sargunv.maplibrecompose.expressions.dsl.const
 import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import io.github.dellisd.spatialk.geojson.Feature
 import platform.Foundation.NSURL
@@ -21,6 +26,15 @@ public actual class VectorSource : Source {
     sourceLayerIds: Set<String>,
     predicate: Expression<BooleanValue>,
   ): List<Feature> {
-    TODO()
+    return impl
+      .featuresInSourceLayersWithIdentifiers(
+        sourceLayerIdentifiers = sourceLayerIds,
+        predicate =
+          predicate
+            .takeUnless { it == const(true) }
+            ?.compile(ExpressionContext.None)
+            ?.toNSPredicate(),
+      )
+      .map { (it as MLNFeatureProtocol).toFeature() }
   }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,8 +1,18 @@
 package dev.sargunv.maplibrecompose.core.source
 
 import cocoapods.MapLibre.MLNVectorTileSource
+import dev.sargunv.maplibrecompose.expressions.ast.CompiledExpression
+import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
+import io.github.dellisd.spatialk.geojson.Feature
 import platform.Foundation.NSURL
 
 public actual class VectorSource actual constructor(id: String, uri: String) : Source() {
   override val impl: MLNVectorTileSource = MLNVectorTileSource(id, NSURL(string = uri))
+
+  public actual fun querySourceFeatures(
+    sourceLayerIds: Set<String>,
+    predicate: CompiledExpression<BooleanValue>?
+  ): List<Feature> {
+    TODO()
+  }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -6,8 +6,16 @@ import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import io.github.dellisd.spatialk.geojson.Feature
 import platform.Foundation.NSURL
 
-public actual class VectorSource actual constructor(id: String, uri: String) : Source() {
-  override val impl: MLNVectorTileSource = MLNVectorTileSource(id, NSURL(string = uri))
+public actual class VectorSource : Source {
+  override val impl: MLNVectorTileSource
+
+  internal constructor(source: MLNVectorTileSource) {
+    impl = source
+  }
+
+  public actual constructor(id: String, uri: String) : super() {
+    this.impl = MLNVectorTileSource(id, NSURL(string = uri))
+  }
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -11,7 +11,7 @@ public actual class VectorSource actual constructor(id: String, uri: String) : S
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,
-    predicate: CompiledExpression<BooleanValue>?
+    predicate: CompiledExpression<BooleanValue>?,
   ): List<Feature> {
     TODO()
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -9,7 +9,7 @@ public actual class VectorSource actual constructor(id: String, uri: String) : S
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,
-    predicate: CompiledExpression<BooleanValue>?
+    predicate: CompiledExpression<BooleanValue>?,
   ): List<Feature> {
     TODO()
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,6 +1,6 @@
 package dev.sargunv.maplibrecompose.core.source
 
-import dev.sargunv.maplibrecompose.expressions.ast.CompiledExpression
+import dev.sargunv.maplibrecompose.expressions.ast.Expression
 import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import io.github.dellisd.spatialk.geojson.Feature
 
@@ -9,7 +9,7 @@ public actual class VectorSource actual constructor(id: String, uri: String) : S
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,
-    predicate: CompiledExpression<BooleanValue>?,
+    predicate: Expression<BooleanValue>,
   ): List<Feature> {
     TODO()
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -1,5 +1,16 @@
 package dev.sargunv.maplibrecompose.core.source
 
+import dev.sargunv.maplibrecompose.expressions.ast.CompiledExpression
+import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
+import io.github.dellisd.spatialk.geojson.Feature
+
 public actual class VectorSource actual constructor(id: String, uri: String) : Source() {
   override val impl: Nothing = TODO()
+
+  public actual fun querySourceFeatures(
+    sourceLayerIds: Set<String>,
+    predicate: CompiledExpression<BooleanValue>?
+  ): List<Feature> {
+    TODO()
+  }
 }


### PR DESCRIPTION
Related to #39, but not fixing the issue entirely, as the implementations are only for Android. I don't have access to a Mac right now, so I can't implement it for iOS.

Example of usage:
``` kotlin
val vectorSource = styleState.getSource("openmaptiles") as? VectorSource
val features = vectorSource?.querySourceFeatures(setOf("landuse"), null)
```

The first commit was to make it possible to cast Source to VectorSource, GeoJsonSource, and RasterSource. Exposed `getSource()` and `getSources()` make it possible to get a source outside of the Composable function as opposed to `getBaseSource()`