### PR TITLE
Fixed local styles used in Style Switcher Demo

### DIFF
--- a/demo-app/src/commonMain/composeResources/files/styles/colorful.json
+++ b/demo-app/src/commonMain/composeResources/files/styles/colorful.json
@@ -5,8 +5,13 @@
     "maputnik:renderer": "mbgljs",
     "license": "https://creativecommons.org/publicdomain/zero/1.0/"
   },
-  "glyphs": "https://tiles.versatiles.org/assets/fonts/{fontstack}/{range}.pbf",
-  "sprite": "https://tiles.versatiles.org/assets/sprites/sprites",
+  "glyphs": "https://tiles.versatiles.org/assets/glyphs/{fontstack}/{range}.pbf",
+  "sprite": [
+    {
+      "id": "basics",
+      "url": "https://tiles.versatiles.org/assets/sprites/basics/sprites"
+    }
+  ],
   "sources": {
     "versatiles-shortbread": {
       "tilejson": "3.0.0",

--- a/demo-app/src/commonMain/composeResources/files/styles/eclipse.json
+++ b/demo-app/src/commonMain/composeResources/files/styles/eclipse.json
@@ -5,8 +5,13 @@
     "maputnik:renderer": "mbgljs",
     "license": "https://creativecommons.org/publicdomain/zero/1.0/"
   },
-  "glyphs": "https://tiles.versatiles.org/assets/fonts/{fontstack}/{range}.pbf",
-  "sprite": "https://tiles.versatiles.org/assets/sprites/sprites",
+  "glyphs": "https://tiles.versatiles.org/assets/glyphs/{fontstack}/{range}.pbf",
+  "sprite": [
+    {
+      "id": "basics",
+      "url": "https://tiles.versatiles.org/assets/sprites/basics/sprites"
+    }
+  ],
   "sources": {
     "versatiles-shortbread": {
       "tilejson": "3.0.0",


### PR DESCRIPTION
I noticed that the eclipse and the colorful styles stopped working on Style Switcher Demo. It happened because of the broken URLs to sprites and glyphs. I took new ones from [versatiles-style](https://github.com/versatiles-org/versatiles-style)