### PR TITLE
Fixed crash when style is not fully loaded

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidStyle.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidStyle.kt
@@ -19,11 +19,11 @@ internal class AndroidStyle(style: MLNStyle) : Style {
   private var impl: MLNStyle = style
 
   override fun addImage(id: String, image: ImageBitmap, sdf: Boolean) {
-    impl.addImage(id, image.asAndroidBitmap(), sdf)
+    if (impl.isFullyLoaded) impl.addImage(id, image.asAndroidBitmap(), sdf)
   }
 
   override fun removeImage(id: String) {
-    impl.removeImage(id)
+    if (impl.isFullyLoaded) impl.removeImage(id)
   }
 
   private fun MLNSource.toSource() =
@@ -35,46 +35,46 @@ internal class AndroidStyle(style: MLNStyle) : Style {
     }
 
   override fun getSource(id: String): Source? {
-    return impl.getSource(id)?.toSource()
+    return if (impl.isFullyLoaded) impl.getSource(id)?.toSource() else null
   }
 
   override fun getSources(): List<Source> {
-    return impl.sources.map { it.toSource() }
+    return if (impl.isFullyLoaded) impl.sources.map { it.toSource() } else emptyList()
   }
 
   override fun addSource(source: Source) {
-    impl.addSource(source.impl)
+    if (impl.isFullyLoaded) impl.addSource(source.impl)
   }
 
   override fun removeSource(source: Source) {
-    impl.removeSource(source.impl)
+    if (impl.isFullyLoaded) impl.removeSource(source.impl)
   }
 
   override fun getLayer(id: String): Layer? {
-    return impl.getLayer(id)?.let { UnknownLayer(it) }
+    return if (impl.isFullyLoaded) impl.getLayer(id)?.let { UnknownLayer(it) } else null
   }
 
   override fun getLayers(): List<Layer> {
-    return impl.layers.map { UnknownLayer(it) }
+    return if (impl.isFullyLoaded) impl.layers.map { UnknownLayer(it) } else return emptyList()
   }
 
   override fun addLayer(layer: Layer) {
-    impl.addLayer(layer.impl)
+    if (impl.isFullyLoaded) impl.addLayer(layer.impl)
   }
 
   override fun addLayerAbove(id: String, layer: Layer) {
-    impl.addLayerAbove(layer.impl, id)
+    if (impl.isFullyLoaded) impl.addLayerAbove(layer.impl, id)
   }
 
   override fun addLayerBelow(id: String, layer: Layer) {
-    impl.addLayerBelow(layer.impl, id)
+    if (impl.isFullyLoaded) impl.addLayerBelow(layer.impl, id)
   }
 
   override fun addLayerAt(index: Int, layer: Layer) {
-    impl.addLayerAt(layer.impl, index)
+    if (impl.isFullyLoaded) impl.addLayerAt(layer.impl, index)
   }
 
   override fun removeLayer(layer: Layer) {
-    impl.removeLayer(layer.impl)
+    if (impl.isFullyLoaded) impl.removeLayer(layer.impl)
   }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidStyle.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidStyle.kt
@@ -18,12 +18,14 @@ import org.maplibre.android.style.sources.VectorSource as MLNVectorSource
 internal class AndroidStyle(style: MLNStyle) : Style {
   private var impl: MLNStyle = style
 
+  override var isLoaded: Boolean = true
+
   override fun addImage(id: String, image: ImageBitmap, sdf: Boolean) {
-    if (impl.isFullyLoaded) impl.addImage(id, image.asAndroidBitmap(), sdf)
+    impl.addImage(id, image.asAndroidBitmap(), sdf)
   }
 
   override fun removeImage(id: String) {
-    if (impl.isFullyLoaded) impl.removeImage(id)
+    impl.removeImage(id)
   }
 
   private fun MLNSource.toSource() =
@@ -35,46 +37,46 @@ internal class AndroidStyle(style: MLNStyle) : Style {
     }
 
   override fun getSource(id: String): Source? {
-    return if (impl.isFullyLoaded) impl.getSource(id)?.toSource() else null
+    return impl.getSource(id)?.toSource()
   }
 
   override fun getSources(): List<Source> {
-    return if (impl.isFullyLoaded) impl.sources.map { it.toSource() } else emptyList()
+    return impl.sources.map { it.toSource() }
   }
 
   override fun addSource(source: Source) {
-    if (impl.isFullyLoaded) impl.addSource(source.impl)
+    impl.addSource(source.impl)
   }
 
   override fun removeSource(source: Source) {
-    if (impl.isFullyLoaded) impl.removeSource(source.impl)
+    impl.removeSource(source.impl)
   }
 
   override fun getLayer(id: String): Layer? {
-    return if (impl.isFullyLoaded) impl.getLayer(id)?.let { UnknownLayer(it) } else null
+    return impl.getLayer(id)?.let { UnknownLayer(it) }
   }
 
   override fun getLayers(): List<Layer> {
-    return if (impl.isFullyLoaded) impl.layers.map { UnknownLayer(it) } else return emptyList()
+    return impl.layers.map { UnknownLayer(it) }
   }
 
   override fun addLayer(layer: Layer) {
-    if (impl.isFullyLoaded) impl.addLayer(layer.impl)
+    impl.addLayer(layer.impl)
   }
 
   override fun addLayerAbove(id: String, layer: Layer) {
-    if (impl.isFullyLoaded) impl.addLayerAbove(layer.impl, id)
+    impl.addLayerAbove(layer.impl, id)
   }
 
   override fun addLayerBelow(id: String, layer: Layer) {
-    if (impl.isFullyLoaded) impl.addLayerBelow(layer.impl, id)
+    impl.addLayerBelow(layer.impl, id)
   }
 
   override fun addLayerAt(index: Int, layer: Layer) {
-    if (impl.isFullyLoaded) impl.addLayerAt(layer.impl, index)
+    impl.addLayerAt(layer.impl, index)
   }
 
   override fun removeLayer(layer: Layer) {
-    if (impl.isFullyLoaded) impl.removeLayer(layer.impl)
+    impl.removeLayer(layer.impl)
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -113,6 +113,9 @@ public fun MaplibreMap(
       object : MaplibreMap.Callbacks {
         override fun onStyleChanged(map: MaplibreMap, style: Style?) {
           map as StandardMaplibreMap
+
+          if (style == null) rememberedStyle?.isLoaded = false
+
           styleState.attach(style)
           rememberedStyle = style
           cameraState.metersPerDpAtTargetState.value =
@@ -133,6 +136,8 @@ public fun MaplibreMap(
         override fun onCameraMoveEnded(map: MaplibreMap) {}
 
         private fun layerNodesInOrder(): List<LayerNode<*>> {
+          if (styleComposition?.style?.isLoaded != true) return emptyList()
+
           val layerNodes =
             (styleComposition?.children?.filterIsInstance<LayerNode<*>>() ?: emptyList())
               .associateBy { node -> node.layer.id }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
@@ -22,7 +22,7 @@ public class StyleState internal constructor() {
 
   public fun queryAttributionLinks(): List<AttributionLink> {
     // TODO expose this as State somehow?
-    return style?.getSources()?.flatMap { it.attributionLinks } ?: emptyList()
+    return getStyleIfLoaded()?.getSources()?.flatMap { it.attributionLinks } ?: emptyList()
   }
 
   /**
@@ -30,7 +30,7 @@ public class StyleState internal constructor() {
    *
    * @return A list of sources, or an empty list if the style is not fully loaded or has no sources.
    */
-  public fun getSources(): List<Source> = style?.getSources() ?: emptyList()
+  public fun getSources(): List<Source> = getStyleIfLoaded()?.getSources() ?: emptyList()
 
   /**
    * Retrieves a source by its [id].
@@ -39,5 +39,9 @@ public class StyleState internal constructor() {
    * @return The source with the specified ID, or null if no such source exists, or the style is not
    *   fully loaded.
    */
-  public fun getSource(id: String): Source? = style?.getSource(id)
+  public fun getSource(id: String): Source? = getStyleIfLoaded()?.getSource(id)
+
+  private fun getStyleIfLoaded(): Style? {
+    return if (style?.isLoaded == true) style else null
+  }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
@@ -28,7 +28,7 @@ public class StyleState internal constructor() {
   /**
    * Retrieves all sources from the style.
    *
-   * @return A list of sources, or an empty list if the style is null or has no sources.
+   * @return A list of sources, or an empty list if the style is not fully loaded or has no sources.
    */
   public fun getSources(): List<Source> = style?.getSources() ?: emptyList()
 
@@ -36,7 +36,8 @@ public class StyleState internal constructor() {
    * Retrieves a source by its [id].
    *
    * @param id The ID of the source to retrieve.
-   * @return The source with the specified ID, or null if no such source exists.
+   * @return The source with the specified ID, or null if no such source exists, or the style is not
+   *   fully loaded.
    */
   public fun getSource(id: String): Source? = style?.getSource(id)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/ImageManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/ImageManager.kt
@@ -20,6 +20,8 @@ internal class ImageManager(private val node: StyleNode) {
   private val painterBitmaps = mutableMapOf<PainterKey, ImageBitmap>()
 
   internal fun acquireBitmap(key: BitmapKey): String {
+    if (!node.style.isLoaded) return ""
+
     bitmapCounter.increment(key) {
       val id = bitmapIds.addId(key)
       node.logger?.i { "Adding bitmap $id" }
@@ -29,6 +31,8 @@ internal class ImageManager(private val node: StyleNode) {
   }
 
   internal fun releaseBitmap(key: BitmapKey) {
+    if (!node.style.isLoaded) return
+
     bitmapCounter.decrement(key) {
       val id = bitmapIds.removeId(key)
       node.logger?.i { "Removing bitmap $id" }
@@ -50,6 +54,8 @@ internal class ImageManager(private val node: StyleNode) {
   }
 
   internal fun acquirePainter(key: PainterKey): String {
+    if (!node.style.isLoaded) return ""
+
     painterCounter.increment(key) {
       val id = painterIds.addId(key)
       node.logger?.i { "Adding painter $id" }
@@ -62,6 +68,8 @@ internal class ImageManager(private val node: StyleNode) {
   }
 
   internal fun releasePainter(key: PainterKey) {
+    if (!node.style.isLoaded) return
+
     painterCounter.decrement(key) {
       val id = painterIds.removeId(key)
       node.logger?.i { "Removing painter $id" }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/LayerManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/LayerManager.kt
@@ -4,7 +4,7 @@ import dev.sargunv.maplibrecompose.compose.layer.Anchor
 import dev.sargunv.maplibrecompose.core.layer.Layer
 
 internal class LayerManager(private val styleNode: StyleNode) {
-  private val baseLayers = styleNode.style.getLayers().associateBy { it.id }
+  private val baseLayers = getLayers().associateBy { it.id }
 
   private val userLayers = mutableListOf<LayerNode<*>>()
 
@@ -13,6 +13,8 @@ internal class LayerManager(private val styleNode: StyleNode) {
   private val replacementCounters = mutableMapOf<Anchor.Replace, Int>()
 
   internal fun addLayer(node: LayerNode<*>, index: Int) {
+    if (!styleNode.style.isLoaded) return
+
     require(node.layer.id !in baseLayers) {
       "Layer ID '${node.layer.id}' already exists in base style"
     }
@@ -24,6 +26,8 @@ internal class LayerManager(private val styleNode: StyleNode) {
   }
 
   internal fun removeLayer(node: LayerNode<*>, oldIndex: Int) {
+    if (!styleNode.style.isLoaded) return
+
     userLayers.removeAt(oldIndex)
 
     // special handling for Replace anchors
@@ -52,6 +56,8 @@ internal class LayerManager(private val styleNode: StyleNode) {
   }
 
   internal fun applyChanges() {
+    if (!styleNode.style.isLoaded) return
+
     val tailLayerIds = mutableMapOf<Anchor, String>()
     val missedLayers = mutableMapOf<Anchor, MutableList<LayerNode<*>>>()
 
@@ -132,4 +138,7 @@ internal class LayerManager(private val styleNode: StyleNode) {
         is Anchor.Replace -> layerId
         else -> null
       }
+
+  private fun getLayers() =
+    if (styleNode.style.isLoaded) styleNode.style.getLayers() else emptyList()
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/SourceManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/SourceManager.kt
@@ -4,7 +4,7 @@ import dev.sargunv.maplibrecompose.core.source.Source
 
 internal class SourceManager(private val node: StyleNode) {
 
-  private val baseSources = node.style.getSources().associateBy { it.id }
+  private val baseSources = getSources().associateBy { it.id }
   private val sourcesToAdd = mutableListOf<Source>()
   private val counter = ReferenceCounter<Source>()
 
@@ -13,6 +13,8 @@ internal class SourceManager(private val node: StyleNode) {
   }
 
   internal fun addReference(source: Source) {
+    if (!node.style.isLoaded) return
+
     require(source.id !in baseSources) { "Source ID '${source.id}' already exists in base style" }
     counter.increment(source) {
       node.logger?.i { "Queuing source ${source.id} for addition" }
@@ -21,6 +23,8 @@ internal class SourceManager(private val node: StyleNode) {
   }
 
   internal fun removeReference(source: Source) {
+    if (!node.style.isLoaded) return
+
     require(source.id !in baseSources) {
       "Source ID '${source.id}' is part of the base style and can't be removed here"
     }
@@ -31,6 +35,8 @@ internal class SourceManager(private val node: StyleNode) {
   }
 
   internal fun applyChanges() {
+    if (!node.style.isLoaded) return
+
     sourcesToAdd
       .onEach {
         node.logger?.i { "Adding source ${it.id}" }
@@ -38,4 +44,6 @@ internal class SourceManager(private val node: StyleNode) {
       }
       .clear()
   }
+
+  private fun getSources() = if (node.style.isLoaded) node.style.getSources() else emptyList()
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/Style.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/Style.kt
@@ -5,32 +5,74 @@ import dev.sargunv.maplibrecompose.core.layer.Layer
 import dev.sargunv.maplibrecompose.core.source.Source
 
 internal interface Style {
+  /**
+   * Returns true if the style is loaded. Returns false if a new style is underway of being loaded.
+   */
   var isLoaded: Boolean
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun addImage(id: String, image: ImageBitmap, sdf: Boolean)
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun removeImage(id: String)
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun getSource(id: String): Source?
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun getSources(): List<Source>
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun addSource(source: Source)
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun removeSource(source: Source)
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun getLayer(id: String): Layer?
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun getLayers(): List<Layer>
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun addLayer(layer: Layer)
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun addLayerAbove(id: String, layer: Layer)
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun addLayerBelow(id: String, layer: Layer)
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun addLayerAt(index: Int, layer: Layer)
 
+  /**
+   * @throws IllegalStateException on Android if [isLoaded] is false.
+   */
   fun removeLayer(layer: Layer)
 
   object Null : Style {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/Style.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/Style.kt
@@ -5,6 +5,8 @@ import dev.sargunv.maplibrecompose.core.layer.Layer
 import dev.sargunv.maplibrecompose.core.source.Source
 
 internal interface Style {
+  var isLoaded: Boolean
+
   fun addImage(id: String, image: ImageBitmap, sdf: Boolean)
 
   fun removeImage(id: String)
@@ -32,6 +34,8 @@ internal interface Style {
   fun removeLayer(layer: Layer)
 
   object Null : Style {
+    override var isLoaded: Boolean = false
+
     override fun addImage(id: String, image: ImageBitmap, sdf: Boolean) {}
 
     override fun removeImage(id: String) {}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/Style.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/Style.kt
@@ -10,69 +10,43 @@ internal interface Style {
    */
   var isLoaded: Boolean
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun addImage(id: String, image: ImageBitmap, sdf: Boolean)
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun removeImage(id: String)
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun getSource(id: String): Source?
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun getSources(): List<Source>
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun addSource(source: Source)
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun removeSource(source: Source)
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun getLayer(id: String): Layer?
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun getLayers(): List<Layer>
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun addLayer(layer: Layer)
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun addLayerAbove(id: String, layer: Layer)
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun addLayerBelow(id: String, layer: Layer)
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun addLayerAt(index: Int, layer: Layer)
 
-  /**
-   * @throws IllegalStateException on Android if [isLoaded] is false.
-   */
+  /** @throws IllegalStateException on Android if [isLoaded] is false. */
   fun removeLayer(layer: Layer)
 
   object Null : Style {

--- a/lib/maplibre-compose/src/commonTest/kotlin/dev/sargunv/maplibrecompose/compose/FakeStyle.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/dev/sargunv/maplibrecompose/compose/FakeStyle.kt
@@ -15,6 +15,8 @@ internal class FakeStyle(
   private val layerList = layers.toMutableList()
   private val layerMap = layers.associateBy { it.id }.toMutableMap()
 
+  override var isLoaded: Boolean = true
+
   override fun addImage(id: String, image: ImageBitmap, sdf: Boolean) {
     if (id in imageMap) error("Image ID '${id}' already exists in style")
     imageMap[id] = image

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosStyle.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosStyle.kt
@@ -19,6 +19,8 @@ import dev.sargunv.maplibrecompose.core.util.toUIImage
 internal class IosStyle(style: MLNStyle, private val getScale: () -> Float) : Style {
   private var impl: MLNStyle = style
 
+  override var isLoaded: Boolean = true
+
   override fun addImage(id: String, image: ImageBitmap, sdf: Boolean) {
     impl.setImage(image.toUIImage(getScale(), sdf), forName = id)
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/JsStyle.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/JsStyle.kt
@@ -7,6 +7,8 @@ import dev.sargunv.maplibrejs.Map as MlJsMap
 
 internal class JsStyle(internal val impl: MlJsMap) : Style {
 
+  override var isLoaded: Boolean = true
+
   override fun addImage(id: String, image: ImageBitmap, sdf: Boolean) {}
 
   override fun removeImage(id: String) {}


### PR DESCRIPTION
Fixes #252 on Android. This crash doesn't seem to happen on the JS target. I don't know if the problem also occurs on iOS, I was looking at the documentation and couldn't find `isFullyLoaded` equivalent, so it may be an Android-specific crash, but it would be worth to test it also on iOS.

I'm not so familiar with the codebase here, so I'm unsure if skipping the execution of functions or returning a null/empty list is a good solution, so I would appreciate feedback on this. 

Based on my investigation of the code, it looks like all the internal executions of the style's functions happen after the style is already loaded, so it shouldn't skip any execution that should happen on a loaded style.

The crash happens on changing the style trying to execute functions of the dismissed style, so it makes sense to skip it, as it will be executed again after a new style is fully loaded. 

The cases I can think of when this crash could happen:
- after the previous style is dismissed, but before a new style is loaded
- after a new style started loading, but the initialization code from the previous style didn't finish executing yet