### PR TITLE
Fixed delay between loading default map and applying user settings

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
@@ -74,7 +74,7 @@ internal fun AndroidMapView(
               styleUri = styleUri,
               logger = logger,
             )
-            
+
           currentMap?.let { update(it) }
         }
       }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/compose/AndroidMapView.kt
@@ -74,6 +74,8 @@ internal fun AndroidMapView(
               styleUri = styleUri,
               logger = logger,
             )
+            
+          currentMap?.let { update(it) }
         }
       }
     },


### PR DESCRIPTION
I encountered a bug on Android which you can see in the video below.
The camera position is set with zoom 8, and the scale bar is disabled, but after launching an app, for a split second, you can see a map on zoom 0 with a scalebar, after that, it switches to the right settings.

https://github.com/user-attachments/assets/21c40546-23a3-4780-8987-5809e5cf0b94

I figured out that the cause of this behaviour was a delay between `mapView.getMapAsync()` and `update()`.
So what exactly was happening:
1. When `AndroidView()` composable was called for the first time, it called `factory` parameter, which called asynchronous `mapView.getMapAsync()`
2. `update` parameter of `AndroidView()` composable was called, but `currentMap` was null, so it didn't proceed.
3. After some time, `mapView.getMapAsync()` finished execution and created an instance of `AndroidMap()`, which loaded the default map, without user settings applied (i.e. camera state, ornament settings)
4. After some time, `update` parameter of `AndroidView()` composable was called again, this time it called `update()` function which applied user settings.

For the time between the execution of `mapView.getMapAsync()` and `update()`, the app showed the default map.

This PR fixes it.