### PR TITLE
solve typo: Interpolateable -> Interpolatable

### DIFF
--- a/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/dsl/ramps.kt
+++ b/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/dsl/ramps.kt
@@ -5,7 +5,7 @@ import dev.sargunv.maplibrecompose.expressions.ast.FunctionCall
 import dev.sargunv.maplibrecompose.expressions.value.ColorValue
 import dev.sargunv.maplibrecompose.expressions.value.ExpressionValue
 import dev.sargunv.maplibrecompose.expressions.value.FloatValue
-import dev.sargunv.maplibrecompose.expressions.value.InterpolateableValue
+import dev.sargunv.maplibrecompose.expressions.value.InterpolatableValue
 import dev.sargunv.maplibrecompose.expressions.value.InterpolationValue
 
 /**
@@ -39,7 +39,7 @@ public fun <T : ExpressionValue> step(
     )
     .cast()
 
-private fun <T, V : InterpolateableValue<T>> interpolateImpl(
+private fun <T, V : InterpolatableValue<T>> interpolateImpl(
   name: String,
   type: Expression<InterpolationValue>,
   input: Expression<FloatValue>,
@@ -77,7 +77,7 @@ private fun <T, V : InterpolateableValue<T>> interpolateImpl(
  * zoom 24, it is 256. Applied to for example line width, this has the visual effect that the line
  * stays the same width in meters on the map (rather than on the viewport).
  */
-public fun <T, V : InterpolateableValue<T>> interpolate(
+public fun <T, V : InterpolatableValue<T>> interpolate(
   type: Expression<InterpolationValue>,
   input: Expression<FloatValue>,
   vararg stops: Pair<Number, Expression<V>>,

--- a/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/value/unions.kt
+++ b/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/value/unions.kt
@@ -37,4 +37,4 @@ public sealed interface ComparableValue<T> : ExpressionValue
  *
  * @param T the type of values that can be interpolated between.
  */
-public sealed interface InterpolateableValue<T> : ExpressionValue
+public sealed interface InterpolatableValue<T> : ExpressionValue

--- a/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/value/values.kt
+++ b/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/value/values.kt
@@ -37,7 +37,7 @@ public sealed interface BooleanValue : ExpressionValue, EquatableValue
 public sealed interface NumberValue<U> :
   ExpressionValue,
   MatchableValue,
-  InterpolateableValue<U>,
+  InterpolatableValue<U>,
   ComparableValue<NumberValue<U>>,
   EquatableValue
 
@@ -87,7 +87,7 @@ public sealed interface EnumValue<out T> : StringValue {
 }
 
 /** Represents an [ExpressionValue] that resolves to a [Color] value. See [const]. */
-public sealed interface ColorValue : ExpressionValue, InterpolateableValue<ColorValue>
+public sealed interface ColorValue : ExpressionValue, InterpolatableValue<ColorValue>
 
 /**
  * Represents an [ExpressionValue] that resolves to a map value (corresponds to a JSON object). See
@@ -127,7 +127,7 @@ public typealias TextVariableAnchorOffsetValue =
  * @param U the unit type of the number. For dimensionless quantities, use [Number].
  */
 public sealed interface VectorValue<U> :
-  ListValue<NumberValue<U>>, InterpolateableValue<VectorValue<U>>
+  ListValue<NumberValue<U>>, InterpolatableValue<VectorValue<U>>
 
 /**
  * Represents an [ExpressionValue] that reoslves to a 2D vector in some unit.


### PR DESCRIPTION
A breaking change because name of public class is changed, hence v0.7.0.