### PR TITLE
Fix for Missing View Reference in iOS Position Conversion

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -463,11 +463,11 @@ internal class IosMap(
   }
 
   override fun positionFromScreenLocation(offset: DpOffset): Position =
-    mapView.convertPoint(point = offset.toCGPoint(), toCoordinateFromView = null).toPosition()
+    mapView.convertPoint(point = offset.toCGPoint(), toCoordinateFromView = mapView).toPosition()
 
   override fun screenLocationFromPosition(position: Position): DpOffset =
     mapView
-      .convertCoordinate(position.toCLLocationCoordinate2D(), toPointToView = null)
+      .convertCoordinate(position.toCLLocationCoordinate2D(), toPointToView = mapView)
       .toDpOffset()
 
   override fun queryRenderedFeatures(


### PR DESCRIPTION
## Issue
Resolves #298 

## Solution Details
The fix adds the necessary view reference when performing coordinate conversion from screen location to map position in iOS. This ensures that the conversion process has access to all required context information to accurately translate screen coordinates to geographical positions on the map.

## Technical Implementation
The implementation properly references the UIView when calling the conversion methods, ensuring that the MapLibre native iOS SDK has all the context it needs to perform accurate coordinate transformations.

## Affected Components
- iOS-specific coordinate conversion code
- Screen-to-map position translation functionality

## Testing
The fix has been tested on iOS devices and simulators, confirming that:
- Screen coordinates are now correctly converted to map positions
- The functionality works consistently across different iOS versions
- No regression issues were introduced for other platform implementations
