### PR TITLE
Update map before sending map attach signal

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -33,11 +33,13 @@ public fun rememberCameraState(firstPosition: CameraPosition = CameraPosition())
 public class CameraState internal constructor(firstPosition: CameraPosition) {
   internal var map: MaplibreMap? = null
     set(map) {
-      if (map != null && map !== field) {
+      val previousField = field
+      field = map
+
+      if (map != null && map !== previousField) {
         (map as StandardMaplibreMap).setCameraPosition(position)
         mapAttachSignal.trySend(map)
       }
-      field = map
     }
 
   private val mapAttachSignal = Channel<MaplibreMap>()


### PR DESCRIPTION
Currently `CameraState.awaitInitialized()` doesn't work as expected. When it receives `mapAttachSignal`, the `map` variable is still null, so calling `requireMap()` after `CameraState.awaitInitialized()` still crashes. It happens because the `mapAttachSignal` is send before setting `map` variable. This PR fixes this problem.