### PR TITLE
[iOS] Fixed crash when setting geojson while changing style

### DIFF
--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -59,7 +59,10 @@ kotlin {
   cocoapods {
     noPodspec()
     ios.deploymentTarget = project.properties["iosDeploymentTarget"]!!.toString()
-    pod("MapLibre", libs.versions.maplibre.ios.get())
+    pod("MapLibre") {
+      version = libs.versions.maplibre.ios.get()
+      extraOpts = listOf("-Xforeign-exception-mode", "objc-wrap")
+    }
   }
 
   sourceSets {

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -61,7 +61,7 @@ public actual class GeoJsonSource : Source {
     try {
       impl.setURL(NSURL(string = uri))
     } catch (e: ForeignException) {
-      if (e.message.startsWith(MLNInvalidStyleSourceException))
+      if (e.message.startsWith(MLNInvalidStyleSourceException.toString()))
         println("Warning: Attempting to call setUri on an invalid source")
       else throw e
     }
@@ -72,7 +72,7 @@ public actual class GeoJsonSource : Source {
     try {
       impl.setShape(geoJson.toMLNShape())
     } catch (e: ForeignException) {
-      if (e.message.startsWith(MLNInvalidStyleSourceException))
+      if (e.message.startsWith(MLNInvalidStyleSourceException.toString()))
         println("Warning: Attempting to call setData on an invalid source")
       else throw e
     }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -1,5 +1,6 @@
 package dev.sargunv.maplibrecompose.core.source
 
+import cocoapods.MapLibre.MLNInvalidStyleSourceException
 import cocoapods.MapLibre.MLNShapeSource
 import cocoapods.MapLibre.MLNShapeSourceOptionBuffer
 import cocoapods.MapLibre.MLNShapeSourceOptionClusterProperties
@@ -15,6 +16,8 @@ import dev.sargunv.maplibrecompose.core.util.toNSExpression
 import dev.sargunv.maplibrecompose.expressions.ExpressionContext
 import dev.sargunv.maplibrecompose.expressions.ast.FunctionCall
 import io.github.dellisd.spatialk.geojson.GeoJson
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ForeignException
 import platform.Foundation.NSNumber
 import platform.Foundation.NSURL
 
@@ -53,11 +56,25 @@ public actual class GeoJsonSource : Source {
       )
     }
 
+  @OptIn(BetaInteropApi::class)
   public actual fun setUri(uri: String) {
-    impl.setURL(NSURL(string = uri))
+    try {
+      impl.setURL(NSURL(string = uri))
+    } catch (e: ForeignException) {
+      if (e.message.startsWith(MLNInvalidStyleSourceException))
+        println("Warning: Attempting to call setUri on an invalid source")
+      else throw e
+    }
   }
 
+  @OptIn(BetaInteropApi::class)
   public actual fun setData(geoJson: GeoJson) {
-    impl.setShape(geoJson.toMLNShape())
+    try {
+      impl.setShape(geoJson.toMLNShape())
+    } catch (e: ForeignException) {
+      if (e.message.startsWith(MLNInvalidStyleSourceException))
+        println("Warning: Attempting to call setData on an invalid source")
+      else throw e
+    }
   }
 }


### PR DESCRIPTION
When `GeoJsonSource.setUri()` or `GeoJsonSource.setData()` is called while changing styles, on iOS, the exception `MLNInvalidStyleSourceException` is thrown by the validation in Maplibre Native:

https://github.com/maplibre/maplibre-native/blob/92cf551ec1d80c71d9ebe29a737dea601fd9d9c1/platform/darwin/src/MLNShapeSource.mm#L221-L225

On Android, in the same case, Maplibre Native just skips the execution:

https://github.com/maplibre/maplibre-native/blob/92cf551ec1d80c71d9ebe29a737dea601fd9d9c1/platform/android/MapLibreAndroid/src/main/java/org/maplibre/android/style/sources/GeoJsonSource.kt#L236-L242

This PR prevents a crash on iOS and makes the behaviour on iOS consistent with Android.

I'm aware that the solution is not very elegant, but I couldn't find a better way to do that.