### PR TITLE
Add isCameraMoving to CameraState to indicate ongoing camera movement

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraStateDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraStateDemo.kt
@@ -54,6 +54,7 @@ object CameraStateDemo : Demo {
         Row(modifier = Modifier.safeDrawingPadding().wrapContentSize(Alignment.Center)) {
           val pos = cameraState.position
           val scale = cameraState.metersPerDpAtTarget
+          val isCameraMoving = cameraState.isCameraMoving
 
           Cell("Latitude", pos.target.latitude.format(3), Modifier.weight(1.4f))
           Cell("Longitude", pos.target.longitude.format(3), Modifier.weight(1.4f))
@@ -61,6 +62,7 @@ object CameraStateDemo : Demo {
           Cell("Bearing", pos.bearing.format(2), Modifier.weight(1f))
           Cell("Tilt", pos.tilt.format(2), Modifier.weight(1f))
           Cell("Scale", "${scale.roundToInt()}m", Modifier.weight(1f))
+          Cell("IsMoving", isCameraMoving.toString(), Modifier.weight(1.2f))
         }
       }
     }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -49,6 +49,7 @@ public class CameraState(firstPosition: CameraPosition) {
   internal val positionState = mutableStateOf(firstPosition)
   internal val moveReasonState = mutableStateOf(CameraMoveReason.NONE)
   internal val metersPerDpAtTargetState = mutableStateOf(0.0)
+  internal val isCameraMovingState = mutableStateOf(false)
 
   /** how the camera is oriented towards the map */
   // if the map is not yet initialized, we store the value to apply it later
@@ -66,6 +67,10 @@ public class CameraState(firstPosition: CameraPosition) {
   /** meters per dp at the target position. Zero when the map is not initialized yet. */
   public val metersPerDpAtTarget: Double
     get() = metersPerDpAtTargetState.value
+
+  /** whether the camera is currently moving */
+  public val isCameraMoving: Boolean
+    get() = isCameraMovingState.value
 
   /** suspends until the map has been initialized */
   public suspend fun awaitInitialized() {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -121,6 +121,7 @@ public fun MaplibreMap(
 
         override fun onCameraMoveStarted(map: MaplibreMap, reason: CameraMoveReason) {
           cameraState.moveReasonState.value = reason
+          cameraState.isCameraMovingState.value = true
         }
 
         override fun onCameraMoved(map: MaplibreMap) {
@@ -130,7 +131,9 @@ public fun MaplibreMap(
             map.metersPerDpAtLatitude(map.getCameraPosition().target.latitude)
         }
 
-        override fun onCameraMoveEnded(map: MaplibreMap) {}
+        override fun onCameraMoveEnded(map: MaplibreMap) {
+          cameraState.isCameraMovingState.value = false
+        }
 
         private fun layerNodesInOrder(): List<LayerNode<*>> {
           val layerNodes =


### PR DESCRIPTION
Implements a public isCameraMoving property on CameraState that tracks whether the camera is currently being animated or moved by the user. This is updated via onCameraMoveStarted and onCameraMoveEnded.

A visual cell was added to the CameraStateDemo for testing and demonstration.