### PR TITLE
[iOS] Fixed padding when animating camera to bounding box

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -451,7 +451,10 @@ internal class IosMap(
     suspendCoroutine { cont ->
       mapView.flyToCamera(
         camera =
-          mapView.cameraThatFitsCoordinateBounds(boundingBox.toMLNCoordinateBounds()).apply {
+          mapView.cameraThatFitsCoordinateBounds(
+            bounds = boundingBox.toMLNCoordinateBounds(),
+            edgePadding = padding.toEdgeInsets(),
+          ).apply {
             heading = bearing
             pitch = tilt
           },

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -451,13 +451,15 @@ internal class IosMap(
     suspendCoroutine { cont ->
       mapView.flyToCamera(
         camera =
-          mapView.cameraThatFitsCoordinateBounds(
-            bounds = boundingBox.toMLNCoordinateBounds(),
-            edgePadding = padding.toEdgeInsets(),
-          ).apply {
-            heading = bearing
-            pitch = tilt
-          },
+          mapView
+            .cameraThatFitsCoordinateBounds(
+              bounds = boundingBox.toMLNCoordinateBounds(),
+              edgePadding = padding.toEdgeInsets(),
+            )
+            .apply {
+              heading = bearing
+              pitch = tilt
+            },
         withDuration = duration.toDouble(DurationUnit.SECONDS),
         edgePadding = padding.toEdgeInsets(),
         completionHandler = { cont.resume(Unit) },


### PR DESCRIPTION
I noticed that on iOS when I was animating the camera to the bounding box, the padding was not applied. This PR fixes this problem.