### PR TITLE
Fixed chaging size on ios

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/compose/MeasuredBox.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/compose/MeasuredBox.kt
@@ -7,11 +7,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.toSize
 
@@ -21,16 +22,24 @@ internal fun MeasuredBox(
   contents: @Composable (x: Dp, y: Dp, width: Dp, height: Dp) -> Unit,
 ) {
   val density = LocalDensity.current
-  var layoutCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
-  Box(modifier = modifier.onGloballyPositioned { layoutCoordinates = it }) {
-    layoutCoordinates?.let { layoutCoordinates ->
-      with(density) {
-        val size = layoutCoordinates.size.toSize().toDpSize()
-        val pos = layoutCoordinates.positionInParent()
-        val x = pos.x.toDp()
-        val y = pos.y.toDp()
-        if (size.isSpecified) {
-          contents(x, y, size.width, size.height)
+  var positionInParent by remember { mutableStateOf<Offset?>(null) }
+  var size by remember { mutableStateOf<IntSize?>(null) }
+  Box(
+    modifier =
+      modifier.onGloballyPositioned {
+        positionInParent = it.positionInParent()
+        size = it.size
+      }
+  ) {
+    positionInParent?.let { positionInParent ->
+      size?.let { size ->
+        with(density) {
+          val dpSize = size.toSize().toDpSize()
+          val x = positionInParent.x.toDp()
+          val y = positionInParent.y.toDp()
+          if (dpSize.isSpecified) {
+            contents(x, y, dpSize.width, dpSize.height)
+          }
         }
       }
     }


### PR DESCRIPTION
Similar to #328
Correctly updating the size in IosMap is essential to having working `getVisibleRegion()` and `toMLNMapCamera()` (I noticed some zoom jumps when animating camera position).

This PR fixes it.

It looks like size wasn't correctly updated, because `MeasuredBox` was recomposed only the first time `onGloballyPositioned` was called (when it still didn't update the size). Then, when the size was updated, `MeasuredBox` wasn't recomposed, resulting in having the size of the previous screen orientation.

